### PR TITLE
Fixed ram usages for deployment

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,5 +4,5 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
+    deploy:
+      resources:
+        limits:
+          memory: 512M # Limit the container to 128 MB of RAM
     volumes:
       - ./detailing-fe:/app
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6b2dc450-cf27-4848-9ae4-aa725a4082f9)
just added a limit to how much ram can be used so we don't exceed the free version of render our deployment service