### PR TITLE
feat/HD-49 Create an Employee

### DIFF
--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeInviteService.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeInviteService.java
@@ -1,0 +1,6 @@
+package com.example.highenddetailing.employeessubdomain.businesslayer;
+
+public interface EmployeeInviteService {
+    String generateInviteLink();
+    boolean isInviteValid(String token);
+}

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeInviteServiceImpl.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeInviteServiceImpl.java
@@ -27,7 +27,7 @@ public class EmployeeInviteServiceImpl implements EmployeeInviteService {
                 .build();
         inviteRepo.save(invite);
 
-        return "http://localhost:3000/employee-invite/" + token;
+        return "https://highend-zke6.onrender.com/employee-invite/" + token;
     }
 
     @Override

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeInviteServiceImpl.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeInviteServiceImpl.java
@@ -1,0 +1,39 @@
+package com.example.highenddetailing.employeessubdomain.businesslayer;
+
+import com.example.highenddetailing.employeessubdomain.datalayer.EmployeeInvite;
+import com.example.highenddetailing.employeessubdomain.datalayer.EmployeeInviteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmployeeInviteServiceImpl implements EmployeeInviteService {
+    private final EmployeeInviteRepository inviteRepo;
+
+    @Override
+    public String generateInviteLink() {
+        // Generate a random token
+        String token = UUID.randomUUID().toString();
+
+        // expires in 24 hours
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(1);
+
+        EmployeeInvite invite = EmployeeInvite.builder()
+                .inviteToken(token)
+                .expiresAt(expiresAt)
+                .build();
+        inviteRepo.save(invite);
+
+        return "http://localhost:3000/employee-invite/" + token;
+    }
+
+    @Override
+    public boolean isInviteValid(String token) {
+        return inviteRepo.findByInviteToken(token)
+                .filter(inv -> inv.getExpiresAt().isAfter(LocalDateTime.now()))
+                .isPresent();
+    }
+}

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeService.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeService.java
@@ -2,6 +2,7 @@ package com.example.highenddetailing.employeessubdomain.businesslayer;
 
 import com.example.highenddetailing.employeessubdomain.datalayer.Availability;
 import com.example.highenddetailing.employeessubdomain.presentationlayer.AvailabilityResponseModel;
+import com.example.highenddetailing.employeessubdomain.presentationlayer.EmployeeRequestModel;
 import com.example.highenddetailing.employeessubdomain.presentationlayer.EmployeeResponseModel;
 
 import java.util.List;
@@ -18,4 +19,6 @@ public interface EmployeeService {
     List<AvailabilityResponseModel> getAvailabilityForEmployee(String employeeId);
 
     void setAvailabilityForEmployee(String employeeId, List<Availability> newAvailability);
+
+    EmployeeResponseModel createEmployee(EmployeeRequestModel request);
 }

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeServiceImpl.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.highenddetailing.employeessubdomain.datalayer.Employee;
 import com.example.highenddetailing.employeessubdomain.datalayer.EmployeeRepository;
 import com.example.highenddetailing.employeessubdomain.mapperlayer.EmployeeResponseMapper;
 import com.example.highenddetailing.employeessubdomain.presentationlayer.AvailabilityResponseModel;
+import com.example.highenddetailing.employeessubdomain.presentationlayer.EmployeeRequestModel;
 import com.example.highenddetailing.employeessubdomain.presentationlayer.EmployeeResponseModel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +66,23 @@ public class EmployeeServiceImpl implements EmployeeService {
 
         // Save changes to DB
         employeeRepository.save(employee);
+    }
+    @Override
+    public EmployeeResponseModel createEmployee(EmployeeRequestModel request) {
+        Employee newEmployee = Employee.builder()
+                .employeeId(request.getEmployeeId())
+                .first_name(request.getFirst_name())
+                .last_name(request.getLast_name())
+                .position(request.getPosition())
+                .email(request.getEmail())
+                .phone(request.getPhone())
+                .salary(request.getSalary())
+                .imagePath(request.getImagePath())
+                .build();
+
+        Employee savedEmployee = employeeRepository.save(newEmployee);
+
+        return employeeResponseMapper.entityToResponseModel(savedEmployee);
     }
 
 }

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/datalayer/EmployeeInvite.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/datalayer/EmployeeInvite.java
@@ -1,0 +1,26 @@
+package com.example.highenddetailing.employeessubdomain.datalayer;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "employee_invites")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmployeeInvite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String inviteToken;
+    private LocalDateTime expiresAt;
+
+
+}

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/datalayer/EmployeeInviteRepository.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/datalayer/EmployeeInviteRepository.java
@@ -1,0 +1,11 @@
+package com.example.highenddetailing.employeessubdomain.datalayer;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmployeeInviteRepository extends JpaRepository<EmployeeInvite, Long> {
+    Optional<EmployeeInvite> findByInviteToken(String inviteToken);
+}

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/datalayer/InviteResponse.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/datalayer/InviteResponse.java
@@ -1,0 +1,8 @@
+package com.example.highenddetailing.employeessubdomain.datalayer;
+
+public class InviteResponse {
+    public String inviteLink;
+    public InviteResponse(String inviteLink) {
+        this.inviteLink = inviteLink;
+    }
+}

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeController.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeController.java
@@ -46,6 +46,11 @@ public class EmployeeController {
         employeeService.setAvailabilityForEmployee(employeeId, newAvailability);
         return ResponseEntity.ok().build();
     }
+    @PostMapping(consumes = "application/json", produces = "application/json")
+    public ResponseEntity<EmployeeResponseModel> createEmployee(@RequestBody EmployeeRequestModel request) {
+        EmployeeResponseModel createdEmployee = employeeService.createEmployee(request);
+        return ResponseEntity.status(201).body(createdEmployee);
+    }
 
 
 }

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeInviteController.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeInviteController.java
@@ -1,0 +1,30 @@
+package com.example.highenddetailing.employeessubdomain.presentationlayer;
+
+import com.example.highenddetailing.employeessubdomain.businesslayer.EmployeeInviteService;
+import com.example.highenddetailing.employeessubdomain.datalayer.InviteResponse;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+
+@RestController
+@RequestMapping("/api/employee-invites")
+public class EmployeeInviteController {
+
+    private final EmployeeInviteService inviteService;
+
+    public EmployeeInviteController(EmployeeInviteService inviteService) {
+        this.inviteService = inviteService;
+    }
+
+    @PostMapping
+    public InviteResponse createInvite(@RequestBody Map<String, String> request) {
+        String inviteLink = inviteService.generateInviteLink();
+        return new InviteResponse(inviteLink);
+    }
+
+    @GetMapping("/{token}")
+    public boolean validateInvite(@PathVariable String token) {
+        return inviteService.isInviteValid(token);
+    }
+}

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeRequestModel.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeRequestModel.java
@@ -12,4 +12,10 @@ import lombok.NoArgsConstructor;
 public class EmployeeRequestModel {
     private String employeeId;
     private String first_name;
+    private String last_name;
+    private String position;
+    private String email;
+    private String phone;
+    private double salary;
+    private String imagePath;
 }

--- a/detailing-be/src/main/resources/schema.sql
+++ b/detailing-be/src/main/resources/schema.sql
@@ -75,3 +75,9 @@ CREATE TABLE IF NOT EXISTS customers(
     province VARCHAR (50),
     country VARCHAR (50)
     );
+DROP TABLE IF EXISTS employee_invites;
+CREATE TABLE IF NOT EXISTS employee_invites (
+                                                id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                                                invite_token VARCHAR(255) NOT NULL,
+                                                expires_at DATETIME NOT NULL
+);

--- a/detailing-be/src/test/java/com/example/highenddetailing/appointmentsubdomain/businesslayer/AppointmentServiceUnitTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/appointmentsubdomain/businesslayer/AppointmentServiceUnitTest.java
@@ -200,7 +200,16 @@ public class AppointmentServiceUnitTest {
     void whenAppointmentNotFound_thenThrowRuntimeException() {
         // Arrange
         String invalidId = "invalid-id";
-        EmployeeRequestModel request = new EmployeeRequestModel("e1f14c90-ec5e-4f82-a9b7-2548a7325b34", null);
+        EmployeeRequestModel request = new EmployeeRequestModel(
+                "e1f14c90-ec5e-4f82-a9b7-2548a7325b34", // employeeId
+                "John",                                  // first_name
+                "Doe",                                   // last_name
+                "Manager",                               // position
+                "john.doe@example.com",                  // email
+                "123-456-7890",                          // phone
+                75000.0,                                 // salary
+                "/images/john-doe.jpg"                   // imagePath
+        );
 
         when(appointmentRepository.findByAppointmentIdentifier_AppointmentId(invalidId))
                 .thenReturn(Optional.empty());
@@ -219,7 +228,16 @@ public class AppointmentServiceUnitTest {
     void whenEmployeeNotFound_thenThrowRuntimeException() {
         // Arrange
         String appointmentId = "a1f14c90-ec5e-4f82-a9b7-2548a7325b34";
-        EmployeeRequestModel request = new EmployeeRequestModel("non-existent-id", null);
+        EmployeeRequestModel request = new EmployeeRequestModel(
+                "non-existent-id",       // employeeId
+                "Jane",                  // first_name
+                "Doe",                   // last_name
+                "Technician",            // position
+                "jane.doe@example.com",  // email
+                "987-654-3210",          // phone
+                50000.0,                 // salary
+                "/images/jane-doe.jpg"   // imagePath
+        );
 
         Appointment existingAppointment = new Appointment(
                 1,

--- a/detailing-be/src/test/java/com/example/highenddetailing/employeesubdomain/datalayer/EmployeeTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/employeesubdomain/datalayer/EmployeeTest.java
@@ -62,15 +62,26 @@ public class EmployeeTest {
         Employee employee1 = new Employee();
         employee1.setEmployeeId("e1");
         employee1.setFirst_name("Jane");
+        employee1.setLast_name("Doe");
+        employee1.setPosition("Technician");
+        employee1.setEmail("jane.doe@example.com");
+        employee1.setPhone("123-456-7890");
+        employee1.setSalary(60000.0);
+        employee1.setImagePath("/images/jane-doe.jpg");
 
         Employee employee2 = new Employee();
         employee2.setEmployeeId("e1");
         employee2.setFirst_name("Jane");
+        employee2.setLast_name("Doe");
+        employee2.setPosition("Technician");
+        employee2.setEmail("jane.doe@example.com");
+        employee2.setPhone("123-456-7890");
+        employee2.setSalary(60000.0);
+        employee2.setImagePath("/images/jane-doe.jpg");
 
-        // Should be true because they share the same PK (employeeId)
+        // Act & Assert
         assertThat(employee1.equals(employee2)).isTrue();
 
-        // Compare to an unrelated object => false
         assertThat(employee1.equals(new Object())).isFalse();
     }
 

--- a/detailing-be/src/test/java/com/example/highenddetailing/employeesubdomain/presentationlayer/EmployeeRequestModelTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/employeesubdomain/presentationlayer/EmployeeRequestModelTest.java
@@ -40,13 +40,34 @@ public class EmployeeRequestModelTest {
         // Arrange
         String employeeId = "emp123";
         String firstName = "John";
+        String lastName = "Doe";
+        String position = "Technician";
+        String email = "john.doe@example.com";
+        String phone = "123-456-7890";
+        double salary = 60000.0;
+        String imagePath = "/images/john-doe.jpg";
 
         // Act
-        EmployeeRequestModel requestModel = new EmployeeRequestModel(employeeId, firstName);
+        EmployeeRequestModel requestModel = new EmployeeRequestModel(
+                employeeId,
+                firstName,
+                lastName,
+                position,
+                email,
+                phone,
+                salary,
+                imagePath
+        );
 
         // Assert
-        assertEquals(requestModel.getEmployeeId(), employeeId);
-        assertEquals(requestModel.getFirst_name(), firstName);
+        assertEquals(employeeId, requestModel.getEmployeeId());
+        assertEquals(firstName, requestModel.getFirst_name());
+        assertEquals(lastName, requestModel.getLast_name());
+        assertEquals(position, requestModel.getPosition());
+        assertEquals(email, requestModel.getEmail());
+        assertEquals(phone, requestModel.getPhone());
+        assertEquals(salary, requestModel.getSalary(), 0.001);
+        assertEquals(imagePath, requestModel.getImagePath());
     }
 
     @Test
@@ -78,9 +99,38 @@ public class EmployeeRequestModelTest {
     @Test
     void testEqualsAndHashCode() {
         // Arrange
-        EmployeeRequestModel requestModel1 = new EmployeeRequestModel("emp123", "John");
-        EmployeeRequestModel requestModel2 = new EmployeeRequestModel("emp123", "John");
-        EmployeeRequestModel requestModel3 = new EmployeeRequestModel("emp124", "Jane");
+        EmployeeRequestModel requestModel1 = new EmployeeRequestModel(
+                "emp123",    // employeeId
+                "John",      // first_name
+                "Doe",       // last_name
+                "Technician",// position
+                "john.doe@example.com", // email
+                "123-456-7890",         // phone
+                60000.0,                // salary
+                "/images/john-doe.jpg"  // imagePath
+        );
+
+        EmployeeRequestModel requestModel2 = new EmployeeRequestModel(
+                "emp123",    // employeeId
+                "John",      // first_name
+                "Doe",       // last_name
+                "Technician",// position
+                "john.doe@example.com", // email
+                "123-456-7890",         // phone
+                60000.0,                // salary
+                "/images/john-doe.jpg"  // imagePath
+        );
+
+        EmployeeRequestModel requestModel3 = new EmployeeRequestModel(
+                "emp124",    // employeeId
+                "Jane",      // first_name
+                "Smith",     // last_name
+                "Manager",   // position
+                "jane.smith@example.com", // email
+                "987-654-3210",           // phone
+                80000.0,                  // salary
+                "/images/jane-smith.jpg"  // imagePath
+        );
 
         // Act & Assert
         assertThat(requestModel1).isEqualTo(requestModel2);

--- a/detailing-be/src/test/java/com/example/highenddetailing/employeesubdomain/presentationlayer/EmployeeResponseModelTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/employeesubdomain/presentationlayer/EmployeeResponseModelTest.java
@@ -2,6 +2,7 @@ package com.example.highenddetailing.employeesubdomain.presentationlayer;
 
 import com.example.highenddetailing.employeessubdomain.datalayer.Employee;
 import com.example.highenddetailing.employeessubdomain.datalayer.EmployeeIdentifier;
+import com.example.highenddetailing.employeessubdomain.presentationlayer.AvailabilityResponseModel;
 import com.example.highenddetailing.employeessubdomain.presentationlayer.EmployeeRequestModel;
 import com.example.highenddetailing.employeessubdomain.presentationlayer.EmployeeResponseModel;
 import org.junit.jupiter.api.Test;
@@ -114,5 +115,92 @@ public class EmployeeResponseModelTest {
         // Assert
         // Depending on Lombok's default toString, these substrings should appear:
         assertThat(toStringResult).contains("E001", "John", "Doe", "Technician", "john.doe@example.com", "1234567890");
+    }
+    @Test
+    void testEquals() {
+        // Arrange
+        EmployeeResponseModel employee1 = EmployeeResponseModel.builder()
+                .employeeId("E001")
+                .first_name("John")
+                .last_name("Doe")
+                .position("Technician")
+                .email("john.doe@example.com")
+                .phone("1234567890")
+                .salary(45000.0)
+                .imagePath("/images/employees/johndoe.jpg")
+                .build();
+
+        EmployeeResponseModel employee2 = EmployeeResponseModel.builder()
+                .employeeId("E001")
+                .first_name("John")
+                .last_name("Doe")
+                .position("Technician")
+                .email("john.doe@example.com")
+                .phone("1234567890")
+                .salary(45000.0)
+                .imagePath("/images/employees/johndoe.jpg")
+                .build();
+
+        EmployeeResponseModel employee3 = EmployeeResponseModel.builder()
+                .employeeId("E002")
+                .first_name("Jane")
+                .last_name("Smith")
+                .position("Manager")
+                .email("jane.smith@example.com")
+                .phone("0987654321")
+                .salary(55000.0)
+                .imagePath("/images/employees/janesmith.jpg")
+                .build();
+
+        // Act & Assert
+        // Test equality between two identical objects
+        assertThat(employee1.equals(employee2)).isTrue();
+        assertThat(employee1.hashCode()).isEqualTo(employee2.hashCode());
+
+        // Test inequality with a different object
+        assertThat(employee1.equals(employee3)).isFalse();
+        assertThat(employee1.hashCode()).isNotEqualTo(employee3.hashCode());
+
+        // Test inequality with null
+        assertThat(employee1.equals(null)).isFalse();
+
+        // Test inequality with an object of a different class
+        assertThat(employee1.equals(new Object())).isFalse();
+    }
+    @Test
+    void testEqualsAvailability() {
+        // Arrange
+        AvailabilityResponseModel availability1 = new AvailabilityResponseModel(
+                "Monday",
+                "09:00",
+                "17:00"
+        );
+
+        AvailabilityResponseModel availability2 = new AvailabilityResponseModel(
+                "Monday",
+                "09:00",
+                "17:00"
+        );
+
+        AvailabilityResponseModel availability3 = new AvailabilityResponseModel(
+                "Tuesday",
+                "10:00",
+                "18:00"
+        );
+
+        // Act & Assert
+        // Test equality between two identical objects
+        assertThat(availability1.equals(availability2)).isTrue();
+        assertThat(availability1.hashCode()).isEqualTo(availability2.hashCode());
+
+        // Test inequality with a different object
+        assertThat(availability1.equals(availability3)).isFalse();
+        assertThat(availability1.hashCode()).isNotEqualTo(availability3.hashCode());
+
+        // Test inequality with null
+        assertThat(availability1.equals(null)).isFalse();
+
+        // Test inequality with an object of a different class
+        assertThat(availability1.equals(new Object())).isFalse();
     }
 }

--- a/detailing-fe/src/models/EmployeeInviteSuccessPage.tsx
+++ b/detailing-fe/src/models/EmployeeInviteSuccessPage.tsx
@@ -3,47 +3,47 @@ import axios from "axios";
 import { useAuth0 } from "@auth0/auth0-react";
 
 export function EmployeeInviteSuccessPage() {
-    const { isAuthenticated, getIdTokenClaims } = useAuth0();
-    const [status, setStatus] = useState("Loading...");
+  const { isAuthenticated, getIdTokenClaims } = useAuth0();
+  const [status, setStatus] = useState("Loading...");
 
-    useEffect(() => {
-        async function doStuff() {
-            if (!isAuthenticated) {
-                setStatus("Could not find ID token; are you sure you just signed up?");
-                return;
-            }
-            const claims = await getIdTokenClaims();
-            if (!claims) {
-                setStatus("No claims found; are you sure you just signed up?");
-                return;
-            }
-            const sub = claims.sub;
+  useEffect(() => {
+    async function doStuff() {
+      if (!isAuthenticated) {
+        setStatus("Could not find ID token; are you sure you just signed up?");
+        return;
+      }
+      const claims = await getIdTokenClaims();
+      if (!claims) {
+        setStatus("No claims found; are you sure you just signed up?");
+        return;
+      }
+      const sub = claims.sub;
 
-            const formJson = localStorage.getItem("employeeFormData");
-            if (!formJson) {
-                setStatus("No employee form data found.");
-                return;
-            }
-            const data = JSON.parse(formJson);
+      const formJson = localStorage.getItem("employeeFormData");
+      if (!formJson) {
+        setStatus("No employee form data found.");
+        return;
+      }
+      const data = JSON.parse(formJson);
 
-            try {
-                await axios.post("http://localhost:8080/api/employees", {
-                    employeeId: sub,
-                    first_name: data.firstName,
-                    last_name: data.lastName,
-                    position: data.position,
-                    email: data.email,
-                    phone: data.phone,
-                });
-                setStatus("Success! Your employee account is created.");
-                localStorage.removeItem("employeeFormData");
-            } catch (err) {
-                console.error("Error creating employee:", err);
-                setStatus("An error occurred while creating your employee account.");
-            }
-        }
-        doStuff();
-    }, [isAuthenticated, getIdTokenClaims]);
+      try {
+        await axios.post("http://localhost:8080/api/employees", {
+          employeeId: sub,
+          first_name: data.firstName,
+          last_name: data.lastName,
+          position: data.position,
+          email: data.email,
+          phone: data.phone,
+        });
+        setStatus("Success! Your employee account is created.");
+        localStorage.removeItem("employeeFormData");
+      } catch (err) {
+        console.error("Error creating employee:", err);
+        setStatus("An error occurred while creating your employee account.");
+      }
+    }
+    doStuff();
+  }, [isAuthenticated, getIdTokenClaims]);
 
-    return <div>{status}</div>;
+  return <div>{status}</div>;
 }

--- a/detailing-fe/src/models/EmployeeInviteSuccessPage.tsx
+++ b/detailing-fe/src/models/EmployeeInviteSuccessPage.tsx
@@ -27,7 +27,7 @@ export function EmployeeInviteSuccessPage() {
       const data = JSON.parse(formJson);
 
       try {
-        await axios.post("http://localhost:8080/api/employees", {
+        await axios.post("https://highend-zke6.onrender.com/api/employees", {
           employeeId: sub,
           first_name: data.firstName,
           last_name: data.lastName,

--- a/detailing-fe/src/models/EmployeeInviteSuccessPage.tsx
+++ b/detailing-fe/src/models/EmployeeInviteSuccessPage.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { useAuth0 } from "@auth0/auth0-react";
+
+export function EmployeeInviteSuccessPage() {
+    const { isAuthenticated, getIdTokenClaims } = useAuth0();
+    const [status, setStatus] = useState("Loading...");
+
+    useEffect(() => {
+        async function doStuff() {
+            if (!isAuthenticated) {
+                setStatus("Could not find ID token; are you sure you just signed up?");
+                return;
+            }
+            const claims = await getIdTokenClaims();
+            if (!claims) {
+                setStatus("No claims found; are you sure you just signed up?");
+                return;
+            }
+            const sub = claims.sub;
+
+            const formJson = localStorage.getItem("employeeFormData");
+            if (!formJson) {
+                setStatus("No employee form data found.");
+                return;
+            }
+            const data = JSON.parse(formJson);
+
+            try {
+                await axios.post("http://localhost:8080/api/employees", {
+                    employeeId: sub,
+                    first_name: data.firstName,
+                    last_name: data.lastName,
+                    position: data.position,
+                    email: data.email,
+                    phone: data.phone,
+                });
+                setStatus("Success! Your employee account is created.");
+                localStorage.removeItem("employeeFormData");
+            } catch (err) {
+                console.error("Error creating employee:", err);
+                setStatus("An error occurred while creating your employee account.");
+            }
+        }
+        doStuff();
+    }, [isAuthenticated, getIdTokenClaims]);
+
+    return <div>{status}</div>;
+}

--- a/detailing-fe/src/models/EmployeeOnboardingForm.tsx
+++ b/detailing-fe/src/models/EmployeeOnboardingForm.tsx
@@ -4,96 +4,98 @@ import axios from "axios";
 import { useAuth0 } from "@auth0/auth0-react";
 
 export function EmployeeOnboardingForm() {
-    const { token } = useParams<{ token: string }>();
-    const { loginWithRedirect } = useAuth0();
+  const { token } = useParams<{ token: string }>();
+  const { loginWithRedirect } = useAuth0();
 
-    const [firstName, setFirstName] = useState("");
-    const [lastName, setLastName] = useState("");
-    const [position, setPosition] = useState("");
-    const [phone, setPhone] = useState("");
-    const [email, setEmail] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [position, setPosition] = useState("");
+  const [phone, setPhone] = useState("");
+  const [email, setEmail] = useState("");
 
-    const [isInviteValid, setIsInviteValid] = useState<boolean | null>(null);
+  const [isInviteValid, setIsInviteValid] = useState<boolean | null>(null);
 
-    useEffect(() => {
-        async function validateToken() {
-            try {
-                const response = await axios.get(`http://localhost:8080/api/employee-invites/${token}`);
-                setIsInviteValid(response.data === true);
-            } catch (err) {
-                console.error("Error validating token", err);
-                setIsInviteValid(false);
-            }
-        }
-        validateToken();
-    }, [token]);
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-
-        // 1) Save form data
-        const employeeFormData = { firstName, lastName, position, phone, email };
-        localStorage.setItem("employeeFormData", JSON.stringify(employeeFormData));
-
-        // 2) Launch Auth0's sign-up.
-        await loginWithRedirect({
-            authorizationParams: {
-                prompt: "login",
-                screen_hint: "signup",
-            },
-            appState: { returnTo: "/employee-invite-success" },
-        });
-    };
-
-    if (isInviteValid === false) {
-        return <div>Sorry, this invite link is invalid or expired.</div>;
+  useEffect(() => {
+    async function validateToken() {
+      try {
+        const response = await axios.get(
+          `http://localhost:8080/api/employee-invites/${token}`,
+        );
+        setIsInviteValid(response.data === true);
+      } catch (err) {
+        console.error("Error validating token", err);
+        setIsInviteValid(false);
+      }
     }
-    if (isInviteValid === null) {
-        return <div>Validating invite link...</div>;
-    }
+    validateToken();
+  }, [token]);
 
-    return (
-        <div style={{ marginTop: "40px" }}>
-            <h2>Employee Onboarding Form</h2>
-            <form onSubmit={handleSubmit}>
-                <input
-                    type="text"
-                    placeholder="First Name"
-                    value={firstName}
-                    onChange={(e) => setFirstName(e.target.value)}
-                    required
-                />
-                <input
-                    type="text"
-                    placeholder="Last Name"
-                    value={lastName}
-                    onChange={(e) => setLastName(e.target.value)}
-                    required
-                />
-                <input
-                    type="text"
-                    placeholder="Position (e.g. Detailer)"
-                    value={position}
-                    onChange={(e) => setPosition(e.target.value)}
-                    required
-                />
-                <input
-                    type="text"
-                    placeholder="Phone #"
-                    value={phone}
-                    onChange={(e) => setPhone(e.target.value)}
-                    required
-                />
-                <input
-                    type="email"
-                    placeholder="Work Email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    required
-                />
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
 
-                <button type="submit">Submit</button>
-            </form>
-        </div>
-    );
+    // 1) Save form data
+    const employeeFormData = { firstName, lastName, position, phone, email };
+    localStorage.setItem("employeeFormData", JSON.stringify(employeeFormData));
+
+    // 2) Launch Auth0's sign-up.
+    await loginWithRedirect({
+      authorizationParams: {
+        prompt: "login",
+        screen_hint: "signup",
+      },
+      appState: { returnTo: "/employee-invite-success" },
+    });
+  };
+
+  if (isInviteValid === false) {
+    return <div>Sorry, this invite link is invalid or expired.</div>;
+  }
+  if (isInviteValid === null) {
+    return <div>Validating invite link...</div>;
+  }
+
+  return (
+    <div style={{ marginTop: "40px" }}>
+      <h2>Employee Onboarding Form</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="First Name"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Last Name"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Position (e.g. Detailer)"
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Phone #"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+        />
+        <input
+          type="email"
+          placeholder="Work Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  );
 }

--- a/detailing-fe/src/models/EmployeeOnboardingForm.tsx
+++ b/detailing-fe/src/models/EmployeeOnboardingForm.tsx
@@ -19,7 +19,7 @@ export function EmployeeOnboardingForm() {
     async function validateToken() {
       try {
         const response = await axios.get(
-          `http://localhost:8080/api/employee-invites/${token}`,
+          `https://highend-zke6.onrender.com/api/employee-invites/${token}`,
         );
         setIsInviteValid(response.data === true);
       } catch (err) {

--- a/detailing-fe/src/models/EmployeeOnboardingForm.tsx
+++ b/detailing-fe/src/models/EmployeeOnboardingForm.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+import { useAuth0 } from "@auth0/auth0-react";
+
+export function EmployeeOnboardingForm() {
+    const { token } = useParams<{ token: string }>();
+    const { loginWithRedirect } = useAuth0();
+
+    const [firstName, setFirstName] = useState("");
+    const [lastName, setLastName] = useState("");
+    const [position, setPosition] = useState("");
+    const [phone, setPhone] = useState("");
+    const [email, setEmail] = useState("");
+
+    const [isInviteValid, setIsInviteValid] = useState<boolean | null>(null);
+
+    useEffect(() => {
+        async function validateToken() {
+            try {
+                const response = await axios.get(`http://localhost:8080/api/employee-invites/${token}`);
+                setIsInviteValid(response.data === true);
+            } catch (err) {
+                console.error("Error validating token", err);
+                setIsInviteValid(false);
+            }
+        }
+        validateToken();
+    }, [token]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        // 1) Save form data
+        const employeeFormData = { firstName, lastName, position, phone, email };
+        localStorage.setItem("employeeFormData", JSON.stringify(employeeFormData));
+
+        // 2) Launch Auth0's sign-up.
+        await loginWithRedirect({
+            authorizationParams: {
+                prompt: "login",
+                screen_hint: "signup",
+            },
+            appState: { returnTo: "/employee-invite-success" },
+        });
+    };
+
+    if (isInviteValid === false) {
+        return <div>Sorry, this invite link is invalid or expired.</div>;
+    }
+    if (isInviteValid === null) {
+        return <div>Validating invite link...</div>;
+    }
+
+    return (
+        <div style={{ marginTop: "40px" }}>
+            <h2>Employee Onboarding Form</h2>
+            <form onSubmit={handleSubmit}>
+                <input
+                    type="text"
+                    placeholder="First Name"
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                    required
+                />
+                <input
+                    type="text"
+                    placeholder="Last Name"
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                    required
+                />
+                <input
+                    type="text"
+                    placeholder="Position (e.g. Detailer)"
+                    value={position}
+                    onChange={(e) => setPosition(e.target.value)}
+                    required
+                />
+                <input
+                    type="text"
+                    placeholder="Phone #"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    required
+                />
+                <input
+                    type="email"
+                    placeholder="Work Email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                />
+
+                <button type="submit">Submit</button>
+            </form>
+        </div>
+    );
+}

--- a/detailing-fe/src/pages/DashboardPage.css
+++ b/detailing-fe/src/pages/DashboardPage.css
@@ -72,7 +72,9 @@ p {
   border-radius: 8px;
   background-color: #fff;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 .list-item:hover {
@@ -97,7 +99,9 @@ p {
   font-size: 14px;
   font-weight: bold;
   cursor: pointer;
-  transition: background-color 0.3s ease, transform 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    transform 0.3s ease;
 }
 
 .list-details button:hover {
@@ -144,7 +148,10 @@ p {
   font-size: 14px;
   font-weight: bold;
   cursor: pointer;
-  transition: background-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   width: 200px; /* Adjust width */
   text-align: center;

--- a/detailing-fe/src/pages/DashboardPage.css
+++ b/detailing-fe/src/pages/DashboardPage.css
@@ -72,9 +72,7 @@ p {
   border-radius: 8px;
   background-color: #fff;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  transition:
-    transform 0.3s ease,
-    box-shadow 0.3s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .list-item:hover {
@@ -99,9 +97,7 @@ p {
   font-size: 14px;
   font-weight: bold;
   cursor: pointer;
-  transition:
-    background-color 0.3s ease,
-    transform 0.3s ease;
+  transition: background-color 0.3s ease, transform 0.3s ease;
 }
 
 .list-details button:hover {
@@ -120,4 +116,130 @@ p {
 
 .list-item:hover .list-image {
   transform: scale(1.1);
+}
+
+/* Styles for Invite Section */
+.invite-section-container {
+  background-color: #ffffff;
+  padding: 20px;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border: 1px solid #ddd;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  max-width: 800px; /* Matches other section widths */
+  margin: 0 auto; /* Center alignment */
+  position: relative; /* For positioning the close button */
+}
+
+/* Generate Employee Invite Button */
+.invite-section-container button.generate-button {
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  width: 200px; /* Adjust width */
+  text-align: center;
+}
+
+.invite-section-container button.generate-button:hover {
+  background-color: #0056b3;
+  transform: translateY(-3px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+}
+
+.invite-section-container button.generate-button:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.invite-section-container button.generate-button:focus {
+  outline: none;
+  box-shadow: 0 0 5px rgba(0, 91, 187, 0.5);
+}
+
+/* Invite Link Container */
+.invite-link-container {
+  width: 100%;
+  text-align: center;
+  background-color: #e8f4ff;
+  padding: 40px 20px 20px 20px; /* Extra top padding to accommodate close button */
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border: 1px solid #cce7ff;
+  position: relative; /* To position the close button */
+  animation: slideIn 0.3s ease forwards;
+}
+
+/* Close Button */
+.close-button {
+  background-color: #ff4d4d;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 16px;
+  font-weight: bold;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.close-button:hover {
+  background-color: #ff1a1a;
+}
+
+/* Invite Link Text */
+.invite-link-text {
+  font-size: 16px;
+  color: #333;
+  margin-bottom: 15px;
+  font-weight: 500;
+  text-align: center;
+}
+
+/* Textarea Styling */
+textarea {
+  width: 100%;
+  height: 80px; /* Adjusted height */
+  resize: none;
+  border: 1px solid #007bff;
+  border-radius: 8px;
+  font-family: Arial, sans-serif;
+  font-size: 14px;
+  color: #333;
+  background-color: #f4f4f9;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+textarea:focus {
+  outline: none;
+  border-color: #0056b3;
+  box-shadow: 0 0 5px rgba(0, 91, 187, 0.5);
+}
+
+/* Invite Link Container Animation */
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/detailing-fe/src/pages/DashhoardPage.tsx
+++ b/detailing-fe/src/pages/DashhoardPage.tsx
@@ -13,7 +13,7 @@ export default function DashboardPage(): JSX.Element {
   const handleGenerateLink = async () => {
     try {
       const response = await axios.post(
-        "http://localhost:8080/api/employee-invites",
+        "https://highend-zke6.onrender.com/api/employee-invites",
         {},
       );
       setInviteLink(response.data.inviteLink);

--- a/detailing-fe/src/pages/DashhoardPage.tsx
+++ b/detailing-fe/src/pages/DashhoardPage.tsx
@@ -12,7 +12,10 @@ export default function DashboardPage(): JSX.Element {
 
   const handleGenerateLink = async () => {
     try {
-      const response = await axios.post("http://localhost:8080/api/employee-invites", {});
+      const response = await axios.post(
+        "http://localhost:8080/api/employee-invites",
+        {},
+      );
       setInviteLink(response.data.inviteLink);
       setIsOpen(true); // Open the container
     } catch (error) {
@@ -26,41 +29,43 @@ export default function DashboardPage(): JSX.Element {
   };
 
   return (
-      <div>
-        <NavBar />
-        <div className="dashboard-container">
-          <div className="section-container">
-            <h2 className="section-title">Appointments</h2>
-            <AllAppointments />
-          </div>
+    <div>
+      <NavBar />
+      <div className="dashboard-container">
+        <div className="section-container">
+          <h2 className="section-title">Appointments</h2>
+          <AllAppointments />
+        </div>
 
-          <div className="section-container">
-            <h2 className="section-title">Customers</h2>
-            <AllCustomers />
-          </div>
+        <div className="section-container">
+          <h2 className="section-title">Customers</h2>
+          <AllCustomers />
+        </div>
 
-          <div className="invite-section-container">
-            {!isOpen && (
-                <button className="generate-button" onClick={handleGenerateLink}>
-                  Generate Employee Invite
-                </button>
-            )}
+        <div className="invite-section-container">
+          {!isOpen && (
+            <button className="generate-button" onClick={handleGenerateLink}>
+              Generate Employee Invite
+            </button>
+          )}
 
-            {isOpen && (
-                <div className="invite-link-container">
-                  <button className="close-button" onClick={handleClose}>
-                    &times;
-                  </button>
-                  <p className="invite-link-text">Share this link with your new employee:</p>
-                  <textarea value={inviteLink} readOnly />
-                </div>
-            )}
-          </div>
-          <div className="section-container">
-            <h2 className="section-title">Employees</h2>
-            <AllEmployees />
-          </div>
+          {isOpen && (
+            <div className="invite-link-container">
+              <button className="close-button" onClick={handleClose}>
+                &times;
+              </button>
+              <p className="invite-link-text">
+                Share this link with your new employee:
+              </p>
+              <textarea value={inviteLink} readOnly />
+            </div>
+          )}
+        </div>
+        <div className="section-container">
+          <h2 className="section-title">Employees</h2>
+          <AllEmployees />
         </div>
       </div>
+    </div>
   );
 }

--- a/detailing-fe/src/pages/DashhoardPage.tsx
+++ b/detailing-fe/src/pages/DashhoardPage.tsx
@@ -1,31 +1,66 @@
+import React, { useState } from "react";
+import axios from "axios";
 import { NavBar } from "../nav/NavBar";
 import AllCustomers from "../models/AllCustomers";
 import AllAppointments from "../models/AllAppointments";
-
-import React from "react";
-import "./DashboardPage.css";
 import AllEmployees from "../models/allEmployees";
+import "./DashboardPage.css";
 
 export default function DashboardPage(): JSX.Element {
+  const [inviteLink, setInviteLink] = useState("");
+  const [isOpen, setIsOpen] = useState(false); // Toggle state for the container
+
+  const handleGenerateLink = async () => {
+    try {
+      const response = await axios.post("http://localhost:8080/api/employee-invites", {});
+      setInviteLink(response.data.inviteLink);
+      setIsOpen(true); // Open the container
+    } catch (error) {
+      console.error("Error generating invite link:", error);
+    }
+  };
+
+  const handleClose = () => {
+    setIsOpen(false); // Close the container
+    setInviteLink(""); // Optional: Clear the invite link
+  };
+
   return (
-    <div>
-      <NavBar />
-      <div className="dashboard-container">
-        <div className="section-container">
-          <h2 className="section-title">Appointments</h2>
-          <AllAppointments />
-        </div>
+      <div>
+        <NavBar />
+        <div className="dashboard-container">
+          <div className="section-container">
+            <h2 className="section-title">Appointments</h2>
+            <AllAppointments />
+          </div>
 
-        <div className="section-container">
-          <h2 className="section-title">Customers</h2>
-          <AllCustomers />
-        </div>
+          <div className="section-container">
+            <h2 className="section-title">Customers</h2>
+            <AllCustomers />
+          </div>
 
-        <div className="section-container">
-          <h2 className="section-title">Employees</h2>
-          <AllEmployees />
+          <div className="invite-section-container">
+            {!isOpen && (
+                <button className="generate-button" onClick={handleGenerateLink}>
+                  Generate Employee Invite
+                </button>
+            )}
+
+            {isOpen && (
+                <div className="invite-link-container">
+                  <button className="close-button" onClick={handleClose}>
+                    &times;
+                  </button>
+                  <p className="invite-link-text">Share this link with your new employee:</p>
+                  <textarea value={inviteLink} readOnly />
+                </div>
+            )}
+          </div>
+          <div className="section-container">
+            <h2 className="section-title">Employees</h2>
+            <AllEmployees />
+          </div>
         </div>
       </div>
-    </div>
   );
 }

--- a/detailing-fe/src/pages/HomeCallbackHandler.tsx
+++ b/detailing-fe/src/pages/HomeCallbackHandler.tsx
@@ -3,44 +3,43 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useAuth0 } from "@auth0/auth0-react";
 import Home from "./Home";
 
-
 export default function HomeCallbackHandler() {
-    const { handleRedirectCallback } = useAuth0();
-    const location = useLocation();
-    const navigate = useNavigate();
+  const { handleRedirectCallback } = useAuth0();
+  const location = useLocation();
+  const navigate = useNavigate();
 
-    // We'll only run handleRedirectCallback once
-    const [callbackDone, setCallbackDone] = useState(false);
+  // We'll only run handleRedirectCallback once
+  const [callbackDone, setCallbackDone] = useState(false);
 
-    useEffect(() => {
-        async function doCallbackIfNeeded() {
-            // If the URL has ?code=, we do the code exchange
-            if (location.search.includes("code=")) {
-                try {
-                    const { appState } = await handleRedirectCallback();
-                    // If Auth0 was told "appState.returnTo = '/employee-invite-success'", go there
-                    if (appState?.returnTo) {
-                        navigate(appState.returnTo);
-                        return;
-                    }
-                } catch (err) {
-                    console.error("Error in handleRedirectCallback:", err);
-                }
-            }
-            setCallbackDone(true);
+  useEffect(() => {
+    async function doCallbackIfNeeded() {
+      // If the URL has ?code=, we do the code exchange
+      if (location.search.includes("code=")) {
+        try {
+          const { appState } = await handleRedirectCallback();
+          // If Auth0 was told "appState.returnTo = '/employee-invite-success'", go there
+          if (appState?.returnTo) {
+            navigate(appState.returnTo);
+            return;
+          }
+        } catch (err) {
+          console.error("Error in handleRedirectCallback:", err);
         }
-
-        // Only attempt once
-        if (!callbackDone) {
-            doCallbackIfNeeded();
-        }
-    }, [callbackDone, location.search, handleRedirectCallback, navigate]);
-
-    // If we haven't done the callback check, don't show real Home yet
-    if (!callbackDone && location.search.includes("code=")) {
-        return <div>Completing login...</div>;
+      }
+      setCallbackDone(true);
     }
 
-    // Otherwise, show the real Home page
-    return <Home />;
+    // Only attempt once
+    if (!callbackDone) {
+      doCallbackIfNeeded();
+    }
+  }, [callbackDone, location.search, handleRedirectCallback, navigate]);
+
+  // If we haven't done the callback check, don't show real Home yet
+  if (!callbackDone && location.search.includes("code=")) {
+    return <div>Completing login...</div>;
+  }
+
+  // Otherwise, show the real Home page
+  return <Home />;
 }

--- a/detailing-fe/src/pages/HomeCallbackHandler.tsx
+++ b/detailing-fe/src/pages/HomeCallbackHandler.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuth0 } from "@auth0/auth0-react";
+import Home from "./Home";
+
+
+export default function HomeCallbackHandler() {
+    const { handleRedirectCallback } = useAuth0();
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    // We'll only run handleRedirectCallback once
+    const [callbackDone, setCallbackDone] = useState(false);
+
+    useEffect(() => {
+        async function doCallbackIfNeeded() {
+            // If the URL has ?code=, we do the code exchange
+            if (location.search.includes("code=")) {
+                try {
+                    const { appState } = await handleRedirectCallback();
+                    // If Auth0 was told "appState.returnTo = '/employee-invite-success'", go there
+                    if (appState?.returnTo) {
+                        navigate(appState.returnTo);
+                        return;
+                    }
+                } catch (err) {
+                    console.error("Error in handleRedirectCallback:", err);
+                }
+            }
+            setCallbackDone(true);
+        }
+
+        // Only attempt once
+        if (!callbackDone) {
+            doCallbackIfNeeded();
+        }
+    }, [callbackDone, location.search, handleRedirectCallback, navigate]);
+
+    // If we haven't done the callback check, don't show real Home yet
+    if (!callbackDone && location.search.includes("code=")) {
+        return <div>Completing login...</div>;
+    }
+
+    // Otherwise, show the real Home page
+    return <Home />;
+}

--- a/detailing-fe/src/routes/router.tsx
+++ b/detailing-fe/src/routes/router.tsx
@@ -9,12 +9,15 @@ import DashboardPage from "../pages/DashhoardPage";
 import EmployeeDetails from "../models/EmployeeDetails";
 import { OnboardingForm } from "../pages/OnboardingForm";
 import { ProfilePage } from "../pages/ProfilePage";
-import { Navigate } from "react-router-dom"; // Import Navigate
+import { Navigate } from "react-router-dom";
+import {EmployeeOnboardingForm} from "../models/EmployeeOnboardingForm";
+import {EmployeeInviteSuccessPage} from "../models/EmployeeInviteSuccessPage";
+import HomeCallbackHandler from "../pages/HomeCallbackHandler"; // Import Navigate
 
 const router = createBrowserRouter([
   {
     path: AppRoutePath.Default,
-    element: <Navigate to={AppRoutePath.Home} replace={true} />,
+    element: <Navigate to={AppRoutePath.Home} replace />,
   },
   {
     path: AppRoutePath.Onboarding,
@@ -22,7 +25,7 @@ const router = createBrowserRouter([
   },
   {
     path: AppRoutePath.Home,
-    element: <Home />,
+    element: <HomeCallbackHandler />,
   },
   {
     path: AppRoutePath.AllServicesPage,
@@ -47,6 +50,14 @@ const router = createBrowserRouter([
   {
     path: AppRoutePath.Profile,
     element: <ProfilePage />,
+  },
+  {
+    path: "/employee-invite/:token",
+    element: <EmployeeOnboardingForm />
+  },
+  {
+    path: "/employee-invite-success",
+    element: <EmployeeInviteSuccessPage />
   },
 ]);
 

--- a/detailing-fe/src/routes/router.tsx
+++ b/detailing-fe/src/routes/router.tsx
@@ -10,8 +10,8 @@ import EmployeeDetails from "../models/EmployeeDetails";
 import { OnboardingForm } from "../pages/OnboardingForm";
 import { ProfilePage } from "../pages/ProfilePage";
 import { Navigate } from "react-router-dom";
-import {EmployeeOnboardingForm} from "../models/EmployeeOnboardingForm";
-import {EmployeeInviteSuccessPage} from "../models/EmployeeInviteSuccessPage";
+import { EmployeeOnboardingForm } from "../models/EmployeeOnboardingForm";
+import { EmployeeInviteSuccessPage } from "../models/EmployeeInviteSuccessPage";
 import HomeCallbackHandler from "../pages/HomeCallbackHandler";
 import CustomerDetailsPage from "../pages/CustomerDetailsPage";
 
@@ -54,11 +54,11 @@ const router = createBrowserRouter([
   },
   {
     path: "/employee-invite/:token",
-    element: <EmployeeOnboardingForm />
+    element: <EmployeeOnboardingForm />,
   },
   {
     path: "/employee-invite-success",
-    element:<EmployeeInviteSuccessPage/>
+    element: <EmployeeInviteSuccessPage />,
   },
   {
     path: "/customers/:customerId",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "HighEnd",
+  "name": "HighEndDetailing",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -10,8 +10,331 @@
         "react-router-dom": "^7.0.2"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@playwright/test": "^1.49.0",
         "@types/node": "^22.10.1"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.26.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.26.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -23,6 +346,99 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.5",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@playwright/test": {
@@ -161,10 +577,71 @@
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
     },
+    "node_modules/browserslist": {
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001695",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+      "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/cookie": {
       "version": "1.0.2",
@@ -178,6 +655,23 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -196,6 +690,23 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.85",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.85.tgz",
+      "integrity": "sha512-UgTI7ZHxtSjOUwV0vZLpqT604U1Z8L3bq8mAtAKtuRPlMZ/6dLFMYgYnLdXSi/urbVTP2ykDb9EDDUrdIzw4Qg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -210,6 +721,25 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -222,6 +752,31 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
@@ -242,6 +797,29 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -249,6 +827,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "node_modules/playwright": {
       "version": "1.49.0",
@@ -427,6 +1011,15 @@
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "peer": true
     },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
@@ -462,6 +1055,37 @@
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -469,6 +1093,13 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "react-router-dom": "^7.0.2"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@playwright/test": "^1.49.0",
     "@types/node": "^22.10.1"
   },


### PR DESCRIPTION
# Create Employee via Invite Link

### Branch Name
`feat/hd49-create-an-employee`

### Summary
This PR adds functionality to allow employees to be created via an invite link. The flow integrates with Auth0 for login/signup and connects to the backend to store the employee's data.

---

### Key Changes
1. Added `EmployeeOnboardingForm` for employees to fill in their details.
2. Integrated Auth0 signup/login with a redirect to `/employee-invite-success`.
3. Added `EmployeeInviteSuccessPage` to finalize the account creation and display success or error messages.
4. Updated routing to include:
   - `/employee-invite/:token` for onboarding.
   - `/employee-invite-success` for confirmation.

---

### UI Screenshots
#### Admin Dashboard Link Button
![Employee Onboarding Form](https://github.com/user-attachments/assets/efb47709-f3de-4e59-8184-7e2c193f05aa)

#### Admin Dashboard Link Creation 
![Invite Success Page](https://github.com/user-attachments/assets/a46a5c48-d4d1-4f03-b75a-d75ac1712087)