### PR TITLE
feat/HD-56 Employee Availability by Appointment

### DIFF
--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeServiceImpl.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/businesslayer/EmployeeServiceImpl.java
@@ -17,6 +17,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,6 +93,32 @@ public class EmployeeServiceImpl implements EmployeeService {
         return employeeOpt.map(employeeResponseMapper::entityToResponseModel).orElse(null);
     }
 
+
+    public List<EmployeeResponseModel> findEmployeesAvailable(LocalDate date, LocalTime start, LocalTime end) {
+        String dayOfWeek = date.getDayOfWeek().toString();
+        List<Employee> allEmployees = employeeRepository.findAll();
+        List<Employee> matching = new ArrayList<>();
+
+        for (Employee emp : allEmployees) {
+            boolean canDoIt = false;
+            if (emp.getAvailability() != null) {
+                for (Availability slot : emp.getAvailability()) {
+                    if (slot.getDayOfWeek().equalsIgnoreCase(dayOfWeek)) {
+                        LocalTime slotStart = LocalTime.parse(slot.getStartTime());
+                        LocalTime slotEnd = LocalTime.parse(slot.getEndTime());
+                        if (!slotStart.isAfter(start) && !slotEnd.isBefore(end)) {
+                            canDoIt = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (canDoIt) {
+                matching.add(emp);
+            }
+        }
+
+        return employeeResponseMapper.entityListToResponseModel(matching);
+    }
+
 }
-
-

--- a/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeController.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/employeessubdomain/presentationlayer/EmployeeController.java
@@ -10,6 +10,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 
@@ -62,6 +64,21 @@ public class EmployeeController {
         } else {
             return ResponseEntity.notFound().build();
         }
+    }
+    @GetMapping("/available")
+    public ResponseEntity<List<EmployeeResponseModel>> getAvailableEmployees(
+            @RequestParam("date") String dateStr,
+            @RequestParam("startTime") String startTimeStr,
+            @RequestParam("endTime") String endTimeStr
+    ) {
+        LocalDate date = LocalDate.parse(dateStr);
+        LocalTime startTime = LocalTime.parse(startTimeStr);
+        LocalTime endTime   = LocalTime.parse(endTimeStr);
+
+        List<EmployeeResponseModel> availableEmployees =
+                employeeService.findEmployeesAvailable(date, startTime, endTime);
+
+        return ResponseEntity.ok(availableEmployees);
     }
 
 

--- a/detailing-fe/src/models/AllAppointments.tsx
+++ b/detailing-fe/src/models/AllAppointments.tsx
@@ -18,17 +18,22 @@ export default function AllAppointments(): JSX.Element {
   const [loadingAppointments, setLoadingAppointments] = useState<boolean>(true);
 
   // For each appointment: is it loading employees right now?
-  const [loadingEmployeesMap, setLoadingEmployeesMap] = useState<{ [id: string]: boolean }>({});
+  const [loadingEmployeesMap, setLoadingEmployeesMap] = useState<{
+    [id: string]: boolean;
+  }>({});
 
   // For each appointment, we store an array of employees who are actually available
   const [availableEmpsMap, setAvailableEmpsMap] = useState<AvailableEmpMap>({});
 
   // Which employee is selected in the dropdown for each appointment
-  const [selectedEmployee, setSelectedEmployee] = useState<{ [id: string]: string }>({});
+  const [selectedEmployee, setSelectedEmployee] = useState<{
+    [id: string]: string;
+  }>({});
 
   // Rescheduling states
   const [showRescheduleModal, setShowRescheduleModal] = useState(false);
-  const [selectedAppointment, setSelectedAppointment] = useState<AppointmentModel | null>(null);
+  const [selectedAppointment, setSelectedAppointment] =
+    useState<AppointmentModel | null>(null);
   const [newDate, setNewDate] = useState("");
   const [newStartTime, setNewStartTime] = useState("");
   const [newEndTime, setNewEndTime] = useState("");
@@ -53,21 +58,29 @@ export default function AllAppointments(): JSX.Element {
 
   // 2) For each appointment, fetch only the employees who are available for that date & time
   const fetchAvailableEmployees = async (appt: AppointmentModel) => {
-    if (!appt.appointmentDate || !appt.appointmentTime || !appt.appointmentEndTime) return;
+    if (
+      !appt.appointmentDate ||
+      !appt.appointmentTime ||
+      !appt.appointmentEndTime
+    )
+      return;
     try {
       // mark employees as "loading" for this specific appointment
-      setLoadingEmployeesMap((prev) => ({ ...prev, [appt.appointmentId]: true }));
+      setLoadingEmployeesMap((prev) => ({
+        ...prev,
+        [appt.appointmentId]: true,
+      }));
 
       const token = await getAccessTokenSilently();
       const params = new URLSearchParams({
-        date: appt.appointmentDate,        // e.g. "2025-07-02"
-        startTime: appt.appointmentTime,   // e.g. "10:00:00"
-        endTime: appt.appointmentEndTime,  // e.g. "11:00:00"
+        date: appt.appointmentDate, // e.g. "2025-07-02"
+        startTime: appt.appointmentTime, // e.g. "10:00:00"
+        endTime: appt.appointmentEndTime, // e.g. "11:00:00"
       });
       // This endpoint should be implemented in your backend, e.g. /api/employees/available
       const resp = await axios.get<EmployeeModel[]>(
-          `${apiBaseUrl}/employees/available?${params.toString()}`,
-          { headers: { Authorization: `Bearer ${token}` } },
+        `${apiBaseUrl}/employees/available?${params.toString()}`,
+        { headers: { Authorization: `Bearer ${token}` } },
       );
 
       // store in state
@@ -78,7 +91,10 @@ export default function AllAppointments(): JSX.Element {
     } catch (err) {
       console.error("Error fetching available employees:", err);
     } finally {
-      setLoadingEmployeesMap((prev) => ({ ...prev, [appt.appointmentId]: false }));
+      setLoadingEmployeesMap((prev) => ({
+        ...prev,
+        [appt.appointmentId]: false,
+      }));
     }
   };
 
@@ -91,13 +107,16 @@ export default function AllAppointments(): JSX.Element {
 
   // 4) Deleting an appointment
   const handleDelete = async (appointmentId: string): Promise<void> => {
-    if (!window.confirm("Are you sure you want to delete this appointment?")) return;
+    if (!window.confirm("Are you sure you want to delete this appointment?"))
+      return;
     try {
       const token = await getAccessTokenSilently();
       await axios.delete(`${apiBaseUrl}/appointments/${appointmentId}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      setAppointments((prev) => prev.filter((a) => a.appointmentId !== appointmentId));
+      setAppointments((prev) =>
+        prev.filter((a) => a.appointmentId !== appointmentId),
+      );
       alert("Appointment deleted successfully.");
     } catch (error) {
       console.error("Error deleting appointment:", error);
@@ -110,20 +129,23 @@ export default function AllAppointments(): JSX.Element {
     try {
       const token = await getAccessTokenSilently();
       const response = await axios.put(
-          `${apiBaseUrl}/appointments/${appointmentId}/status`,
-          { status: "CONFIRMED" },
-          {
-            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        `${apiBaseUrl}/appointments/${appointmentId}/status`,
+        { status: "CONFIRMED" },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
           },
+        },
       );
       console.log("Appointment confirmed:", response.data);
 
       setAppointments((prev) =>
-          prev.map((appt) =>
-              appt.appointmentId === appointmentId
-                  ? { ...appt, status: "CONFIRMED" }
-                  : appt
-          )
+        prev.map((appt) =>
+          appt.appointmentId === appointmentId
+            ? { ...appt, status: "CONFIRMED" }
+            : appt,
+        ),
       );
     } catch (error) {
       console.error("Error confirming appointment:", error);
@@ -142,25 +164,27 @@ export default function AllAppointments(): JSX.Element {
     try {
       const token = await getAccessTokenSilently();
       const response = await axios.put(
-          `${apiBaseUrl}/appointments/${appointmentId}/assign`,
-          { employeeId },
-          {
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
-            },
+        `${apiBaseUrl}/appointments/${appointmentId}/assign`,
+        { employeeId },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
           },
+        },
       );
       // Update local state with the newly assigned employee name
       setAppointments((prev) =>
-          prev.map((appt) =>
-              appt.appointmentId === appointmentId
-                  ? { ...appt, employeeName: response.data?.employeeName || "N/A" }
-                  : appt
-          )
+        prev.map((appt) =>
+          appt.appointmentId === appointmentId
+            ? { ...appt, employeeName: response.data?.employeeName || "N/A" }
+            : appt,
+        ),
       );
 
-      alert(`Employee assigned successfully to appointment ID: ${appointmentId}`);
+      alert(
+        `Employee assigned successfully to appointment ID: ${appointmentId}`,
+      );
     } catch (error) {
       console.error("Error assigning employee:", error);
       alert("Error assigning employee. Please try again.");
@@ -168,7 +192,10 @@ export default function AllAppointments(): JSX.Element {
   };
 
   // 7) track which employee is chosen
-  const handleEmployeeChange = (appointmentId: string, employeeId: string): void => {
+  const handleEmployeeChange = (
+    appointmentId: string,
+    employeeId: string,
+  ): void => {
     setSelectedEmployee((prev) => ({
       ...prev,
       [appointmentId]: employeeId,
@@ -189,24 +216,27 @@ export default function AllAppointments(): JSX.Element {
     try {
       const token = await getAccessTokenSilently();
       await axios.put(
-          `${apiBaseUrl}/appointments/${selectedAppointment.appointmentId}/reschedule`,
-          { newDate, newStartTime, newEndTime },
-          {
-            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+        `${apiBaseUrl}/appointments/${selectedAppointment.appointmentId}/reschedule`,
+        { newDate, newStartTime, newEndTime },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
           },
+        },
       );
       // update local state
       setAppointments((prev) =>
-          prev.map((appt) =>
-              appt.appointmentId === selectedAppointment.appointmentId
-                  ? {
-                    ...appt,
-                    appointmentDate: newDate,
-                    appointmentTime: newStartTime,
-                    appointmentEndTime: newEndTime,
-                  }
-                  : appt
-          )
+        prev.map((appt) =>
+          appt.appointmentId === selectedAppointment.appointmentId
+            ? {
+                ...appt,
+                appointmentDate: newDate,
+                appointmentTime: newStartTime,
+                appointmentEndTime: newEndTime,
+              }
+            : appt,
+        ),
       );
       alert("Appointment rescheduled successfully.");
       setShowRescheduleModal(false);
@@ -218,90 +248,124 @@ export default function AllAppointments(): JSX.Element {
 
   // 9) Render
   return (
-      <div>
-        {loadingAppointments ? (
-            <p>Loading appointments...</p>
-        ) : (
-            <div className="appointments-container">
-              {appointments.map((appointment) => {
-                const { appointmentId } = appointment;
-                // Are we still fetching employees for this appointment?
-                const loadingEmps = loadingEmployeesMap[appointmentId];
-                // which employees are actually available for this appt
-                const possibleEmployees = availableEmpsMap[appointmentId] || [];
+    <div>
+      {loadingAppointments ? (
+        <p>Loading appointments...</p>
+      ) : (
+        <div className="appointments-container">
+          {appointments.map((appointment) => {
+            const { appointmentId } = appointment;
+            // Are we still fetching employees for this appointment?
+            const loadingEmps = loadingEmployeesMap[appointmentId];
+            // which employees are actually available for this appt
+            const possibleEmployees = availableEmpsMap[appointmentId] || [];
 
-                return (
-                    <div className="appointment-box" key={appointmentId}>
-                      <div className="appointment-details">
-                        <p><strong>Date:</strong> {appointment.appointmentDate}</p>
-                        <p><strong>Time:</strong> {appointment.appointmentTime} - {appointment.appointmentEndTime}</p>
-                        <p><strong>Service Name:</strong> {appointment.serviceName}</p>
-                        <p><strong>Customer Name:</strong> {appointment.customerName}</p>
-                        <p><strong>Employee Name:</strong> {appointment.employeeName || "Not Assigned"}</p>
-                        <p><strong>Status:</strong> {appointment.status}</p>
+            return (
+              <div className="appointment-box" key={appointmentId}>
+                <div className="appointment-details">
+                  <p>
+                    <strong>Date:</strong> {appointment.appointmentDate}
+                  </p>
+                  <p>
+                    <strong>Time:</strong> {appointment.appointmentTime} -{" "}
+                    {appointment.appointmentEndTime}
+                  </p>
+                  <p>
+                    <strong>Service Name:</strong> {appointment.serviceName}
+                  </p>
+                  <p>
+                    <strong>Customer Name:</strong> {appointment.customerName}
+                  </p>
+                  <p>
+                    <strong>Employee Name:</strong>{" "}
+                    {appointment.employeeName || "Not Assigned"}
+                  </p>
+                  <p>
+                    <strong>Status:</strong> {appointment.status}
+                  </p>
 
-                        <label><strong>Assign Employee:</strong></label>
-                        {loadingEmps ? (
-                            <p>Loading available employees...</p>
-                        ) : (
-                            <select
-                                value={selectedEmployee[appointmentId] || ""}
-                                onChange={(e) => handleEmployeeChange(appointmentId, e.target.value)}
-                            >
-                              <option value="">Select Employee</option>
-                              {possibleEmployees.map((emp) => (
-                                  <option key={emp.employeeId} value={emp.employeeId}>
-                                    {emp.first_name} {emp.last_name}
-                                  </option>
-                              ))}
-                            </select>
-                        )}
+                  <label>
+                    <strong>Assign Employee:</strong>
+                  </label>
+                  {loadingEmps ? (
+                    <p>Loading available employees...</p>
+                  ) : (
+                    <select
+                      value={selectedEmployee[appointmentId] || ""}
+                      onChange={(e) =>
+                        handleEmployeeChange(appointmentId, e.target.value)
+                      }
+                    >
+                      <option value="">Select Employee</option>
+                      {possibleEmployees.map((emp) => (
+                        <option key={emp.employeeId} value={emp.employeeId}>
+                          {emp.first_name} {emp.last_name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
 
-                        <div className="button-container">
-                          <button onClick={() => handleAssignEmployee(appointmentId)}>
-                            Assign
-                          </button>
-                          <button
-                              onClick={() => handleConfirm(appointmentId)}
-                              disabled={appointment.status === "CONFIRMED"}
-                          >
-                            {appointment.status === "CONFIRMED" ? "Confirmed" : "Confirm"}
-                          </button>
-                          <button
-                              className="delete-button"
-                              onClick={() => handleDelete(appointmentId)}
-                          >
-                            Delete
-                          </button>
-                          <button onClick={() => handleRescheduleClick(appointment)}>
-                            Reschedule
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                );
-              })}
-            </div>
-        )}
-
-        {showRescheduleModal && (
-            <div className="modal">
-              <h3>Reschedule Appointment</h3>
-              <label>Date:</label>
-              <input type="date" value={newDate} onChange={(e) => setNewDate(e.target.value)} />
-
-              <label>Start Time:</label>
-              <input type="time" value={newStartTime} onChange={(e) => setNewStartTime(e.target.value)} />
-
-              <label>End Time:</label>
-              <input type="time" value={newEndTime} onChange={(e) => setNewEndTime(e.target.value)} />
-
-              <div className="modal-buttons">
-                <button onClick={handleReschedule}>Confirm</button>
-                <button onClick={() => setShowRescheduleModal(false)}>Cancel</button>
+                  <div className="button-container">
+                    <button onClick={() => handleAssignEmployee(appointmentId)}>
+                      Assign
+                    </button>
+                    <button
+                      onClick={() => handleConfirm(appointmentId)}
+                      disabled={appointment.status === "CONFIRMED"}
+                    >
+                      {appointment.status === "CONFIRMED"
+                        ? "Confirmed"
+                        : "Confirm"}
+                    </button>
+                    <button
+                      className="delete-button"
+                      onClick={() => handleDelete(appointmentId)}
+                    >
+                      Delete
+                    </button>
+                    <button onClick={() => handleRescheduleClick(appointment)}>
+                      Reschedule
+                    </button>
+                  </div>
+                </div>
               </div>
-            </div>
-        )}
-      </div>
+            );
+          })}
+        </div>
+      )}
+
+      {showRescheduleModal && (
+        <div className="modal">
+          <h3>Reschedule Appointment</h3>
+          <label>Date:</label>
+          <input
+            type="date"
+            value={newDate}
+            onChange={(e) => setNewDate(e.target.value)}
+          />
+
+          <label>Start Time:</label>
+          <input
+            type="time"
+            value={newStartTime}
+            onChange={(e) => setNewStartTime(e.target.value)}
+          />
+
+          <label>End Time:</label>
+          <input
+            type="time"
+            value={newEndTime}
+            onChange={(e) => setNewEndTime(e.target.value)}
+          />
+
+          <div className="modal-buttons">
+            <button onClick={handleReschedule}>Confirm</button>
+            <button onClick={() => setShowRescheduleModal(false)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/detailing-fe/src/models/AllAppointments.tsx
+++ b/detailing-fe/src/models/AllAppointments.tsx
@@ -5,35 +5,41 @@ import { EmployeeModel } from "./dtos/EmployeeModel";
 import "./AllAppointments.css";
 import { useAuth0 } from "@auth0/auth0-react";
 
+interface AvailableEmpMap {
+  [appointmentId: string]: EmployeeModel[]; // For each appt, store an array of employees
+}
+
 export default function AllAppointments(): JSX.Element {
-  const [appointments, setAppointments] = useState<AppointmentModel[]>([]);
   const apiBaseUrl = process.env.REACT_APP_API_BASE_URL;
-
-  const [employees, setEmployees] = useState<EmployeeModel[]>([]);
-  const [selectedEmployee, setSelectedEmployee] = useState<{
-    [key: string]: string;
-  }>({});
-  const [loadingAppointments, setLoadingAppointments] = useState<boolean>(true);
-  const [loadingEmployees, setLoadingEmployees] = useState<boolean>(true);
-
-  const [showRescheduleModal, setShowRescheduleModal] =
-    useState<boolean>(false);
-  const [selectedAppointment, setSelectedAppointment] =
-    useState<AppointmentModel | null>(null);
-  const [newDate, setNewDate] = useState<string>("");
-  const [newStartTime, setNewStartTime] = useState<string>("");
-  const [newEndTime, setNewEndTime] = useState<string>("");
-
   const { getAccessTokenSilently } = useAuth0();
 
+  // All appointments
+  const [appointments, setAppointments] = useState<AppointmentModel[]>([]);
+  const [loadingAppointments, setLoadingAppointments] = useState<boolean>(true);
+
+  // For each appointment: is it loading employees right now?
+  const [loadingEmployeesMap, setLoadingEmployeesMap] = useState<{ [id: string]: boolean }>({});
+
+  // For each appointment, we store an array of employees who are actually available
+  const [availableEmpsMap, setAvailableEmpsMap] = useState<AvailableEmpMap>({});
+
+  // Which employee is selected in the dropdown for each appointment
+  const [selectedEmployee, setSelectedEmployee] = useState<{ [id: string]: string }>({});
+
+  // Rescheduling states
+  const [showRescheduleModal, setShowRescheduleModal] = useState(false);
+  const [selectedAppointment, setSelectedAppointment] = useState<AppointmentModel | null>(null);
+  const [newDate, setNewDate] = useState("");
+  const [newStartTime, setNewStartTime] = useState("");
+  const [newEndTime, setNewEndTime] = useState("");
+
+  // 1) Fetch all appointments once
   useEffect(() => {
     const fetchAppointments = async (): Promise<void> => {
       try {
         const token = await getAccessTokenSilently();
         const response = await axios.get(`${apiBaseUrl}/appointments`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          headers: { Authorization: `Bearer ${token}` },
         });
         setAppointments(response.data);
       } catch (error) {
@@ -42,78 +48,82 @@ export default function AllAppointments(): JSX.Element {
         setLoadingAppointments(false);
       }
     };
-
     fetchAppointments();
-  }, [getAccessTokenSilently]);
+  }, [getAccessTokenSilently, apiBaseUrl]);
 
+  // 2) For each appointment, fetch only the employees who are available for that date & time
+  const fetchAvailableEmployees = async (appt: AppointmentModel) => {
+    if (!appt.appointmentDate || !appt.appointmentTime || !appt.appointmentEndTime) return;
+    try {
+      // mark employees as "loading" for this specific appointment
+      setLoadingEmployeesMap((prev) => ({ ...prev, [appt.appointmentId]: true }));
+
+      const token = await getAccessTokenSilently();
+      const params = new URLSearchParams({
+        date: appt.appointmentDate,        // e.g. "2025-07-02"
+        startTime: appt.appointmentTime,   // e.g. "10:00:00"
+        endTime: appt.appointmentEndTime,  // e.g. "11:00:00"
+      });
+      // This endpoint should be implemented in your backend, e.g. /api/employees/available
+      const resp = await axios.get<EmployeeModel[]>(
+          `${apiBaseUrl}/employees/available?${params.toString()}`,
+          { headers: { Authorization: `Bearer ${token}` } },
+      );
+
+      // store in state
+      setAvailableEmpsMap((prev) => ({
+        ...prev,
+        [appt.appointmentId]: resp.data,
+      }));
+    } catch (err) {
+      console.error("Error fetching available employees:", err);
+    } finally {
+      setLoadingEmployeesMap((prev) => ({ ...prev, [appt.appointmentId]: false }));
+    }
+  };
+
+  // 3) Whenever we get or update the appointments list, fetch employees for each appointment
   useEffect(() => {
-    const fetchEmployees = async (): Promise<void> => {
-      try {
-        const token = await getAccessTokenSilently();
-        const response = await axios.get(`${apiBaseUrl}/employees`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        setEmployees(response.data);
-      } catch (error) {
-        console.error("Error fetching employees:", error);
-      } finally {
-        setLoadingEmployees(false);
-      }
-    };
+    appointments.forEach((appt) => {
+      fetchAvailableEmployees(appt);
+    });
+  }, [appointments]);
 
-    fetchEmployees();
-  }, [getAccessTokenSilently]);
-
+  // 4) Deleting an appointment
   const handleDelete = async (appointmentId: string): Promise<void> => {
-    if (!window.confirm("Are you sure you want to delete this appointment?"))
-      return;
-
+    if (!window.confirm("Are you sure you want to delete this appointment?")) return;
     try {
       const token = await getAccessTokenSilently();
       await axios.delete(`${apiBaseUrl}/appointments/${appointmentId}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
       });
-
-      setAppointments((prevAppointments) =>
-        prevAppointments.filter(
-          (appointment) => appointment.appointmentId !== appointmentId,
-        ),
-      );
-
+      setAppointments((prev) => prev.filter((a) => a.appointmentId !== appointmentId));
       alert("Appointment deleted successfully.");
     } catch (error) {
       console.error("Error deleting appointment:", error);
       alert("Error deleting appointment. Please try again.");
-      console.log("Deleting appointment with ID:", appointmentId);
     }
   };
 
-  // Handle Confirm Appointment
+  // 5) Confirm appointment
   const handleConfirm = async (appointmentId: string): Promise<void> => {
     try {
       const token = await getAccessTokenSilently();
       const response = await axios.put(
-        `${apiBaseUrl}/appointments/${appointmentId}/status`,
-        { status: "CONFIRMED" },
-        {
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
+          `${apiBaseUrl}/appointments/${appointmentId}/status`,
+          { status: "CONFIRMED" },
+          {
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
           },
-        },
       );
       console.log("Appointment confirmed:", response.data);
 
-      setAppointments((prevAppointments) =>
-        prevAppointments.map((appointment) =>
-          appointment.appointmentId === appointmentId
-            ? { ...appointment, status: "CONFIRMED" }
-            : appointment,
-        ),
+      setAppointments((prev) =>
+          prev.map((appt) =>
+              appt.appointmentId === appointmentId
+                  ? { ...appt, status: "CONFIRMED" }
+                  : appt
+          )
       );
     } catch (error) {
       console.error("Error confirming appointment:", error);
@@ -121,9 +131,9 @@ export default function AllAppointments(): JSX.Element {
     }
   };
 
+  // 6) Assign an employee from the dropdown
   const handleAssignEmployee = async (appointmentId: string): Promise<void> => {
     const employeeId = selectedEmployee[appointmentId];
-
     if (!employeeId) {
       alert("Please select an employee.");
       return;
@@ -132,46 +142,40 @@ export default function AllAppointments(): JSX.Element {
     try {
       const token = await getAccessTokenSilently();
       const response = await axios.put(
-        `${apiBaseUrl}/appointments/${appointmentId}/assign`,
-        { employeeId: employeeId },
-        {
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
+          `${apiBaseUrl}/appointments/${appointmentId}/assign`,
+          { employeeId },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
           },
-        },
+      );
+      // Update local state with the newly assigned employee name
+      setAppointments((prev) =>
+          prev.map((appt) =>
+              appt.appointmentId === appointmentId
+                  ? { ...appt, employeeName: response.data?.employeeName || "N/A" }
+                  : appt
+          )
       );
 
-      setAppointments((prevAppointments) =>
-        prevAppointments.map((appointment) =>
-          appointment.appointmentId === appointmentId
-            ? {
-                ...appointment,
-                employeeName: response.data?.employeeName || "N/A",
-              }
-            : appointment,
-        ),
-      );
-
-      alert(
-        `Employee assigned successfully to appointment ID: ${appointmentId}`,
-      );
+      alert(`Employee assigned successfully to appointment ID: ${appointmentId}`);
     } catch (error) {
       console.error("Error assigning employee:", error);
       alert("Error assigning employee. Please try again.");
     }
   };
 
-  const handleEmployeeChange = (
-    appointmentId: string,
-    employeeId: string,
-  ): void => {
-    setSelectedEmployee((prevSelectedEmployee) => ({
-      ...prevSelectedEmployee,
+  // 7) track which employee is chosen
+  const handleEmployeeChange = (appointmentId: string, employeeId: string): void => {
+    setSelectedEmployee((prev) => ({
+      ...prev,
       [appointmentId]: employeeId,
     }));
   };
 
+  // 8) Rescheduling logic
   const handleRescheduleClick = (appointment: AppointmentModel): void => {
     setSelectedAppointment(appointment);
     setNewDate(appointment.appointmentDate);
@@ -182,33 +186,28 @@ export default function AllAppointments(): JSX.Element {
 
   const handleReschedule = async (): Promise<void> => {
     if (!selectedAppointment) return;
-
     try {
       const token = await getAccessTokenSilently();
       await axios.put(
-        `${apiBaseUrl}/appointments/${selectedAppointment.appointmentId}/reschedule`,
-        { newDate, newStartTime, newEndTime },
-        {
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
+          `${apiBaseUrl}/appointments/${selectedAppointment.appointmentId}/reschedule`,
+          { newDate, newStartTime, newEndTime },
+          {
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
           },
-        },
       );
-
-      setAppointments((prevAppointments) =>
-        prevAppointments.map((appointment) =>
-          appointment.appointmentId === selectedAppointment.appointmentId
-            ? {
-                ...appointment,
-                appointmentDate: newDate,
-                appointmentTime: newStartTime,
-                appointmentEndTime: newEndTime,
-              }
-            : appointment,
-        ),
+      // update local state
+      setAppointments((prev) =>
+          prev.map((appt) =>
+              appt.appointmentId === selectedAppointment.appointmentId
+                  ? {
+                    ...appt,
+                    appointmentDate: newDate,
+                    appointmentTime: newStartTime,
+                    appointmentEndTime: newEndTime,
+                  }
+                  : appt
+          )
       );
-
       alert("Appointment rescheduled successfully.");
       setShowRescheduleModal(false);
     } catch (error) {
@@ -217,131 +216,92 @@ export default function AllAppointments(): JSX.Element {
     }
   };
 
+  // 9) Render
   return (
-    <div>
-      {loadingAppointments ? (
-        <p>Loading appointments...</p>
-      ) : (
-        <div className="appointments-container">
-          {appointments.map((appointment) => (
-            <div className="appointment-box" key={appointment.appointmentId}>
-              {/*<img*/}
-              {/*  className="appointment-image"*/}
-              {/*  src={`https://highend-zke6.onrender.com/${appointment.imagePath}`}*/}
-              {/*  alt="appointment"*/}
-              {/*/>*/}
-              <div className="appointment-details">
-                <p>
-                  <strong>Date:</strong> {appointment.appointmentDate}
-                </p>
-                <p>
-                  <strong>Time:</strong> {appointment.appointmentTime}
-                </p>
-                <p>
-                  <strong>Service Name:</strong> {appointment.serviceName}
-                </p>
-                <p>
-                  <strong>Customer Name:</strong> {appointment.customerName}
-                </p>
-                <p>
-                  <strong>Employee Name:</strong>{" "}
-                  {appointment.employeeName || "Not Assigned"}
-                </p>
-                <p>
-                  <strong>Status:</strong> {appointment.status}
-                </p>
+      <div>
+        {loadingAppointments ? (
+            <p>Loading appointments...</p>
+        ) : (
+            <div className="appointments-container">
+              {appointments.map((appointment) => {
+                const { appointmentId } = appointment;
+                // Are we still fetching employees for this appointment?
+                const loadingEmps = loadingEmployeesMap[appointmentId];
+                // which employees are actually available for this appt
+                const possibleEmployees = availableEmpsMap[appointmentId] || [];
 
-                <label htmlFor={`employee-select-${appointment.appointmentId}`}>
-                  <strong>Assign Employee:</strong>
-                </label>
-                {loadingEmployees ? (
-                  <p>Loading employees...</p>
-                ) : (
-                  <select
-                    id={`employee-select-${appointment.appointmentId}`}
-                    value={selectedEmployee[appointment.appointmentId] || ""}
-                    onChange={(e) =>
-                      handleEmployeeChange(
-                        appointment.appointmentId,
-                        e.target.value,
-                      )
-                    }
-                  >
-                    <option value="">Select Employee</option>
-                    {employees.map((employee) => (
-                      <option
-                        key={employee.employeeId}
-                        value={employee.employeeId}
-                      >
-                        {employee.first_name} {employee.last_name}
-                      </option>
-                    ))}
-                  </select>
-                )}
+                return (
+                    <div className="appointment-box" key={appointmentId}>
+                      <div className="appointment-details">
+                        <p><strong>Date:</strong> {appointment.appointmentDate}</p>
+                        <p><strong>Time:</strong> {appointment.appointmentTime} - {appointment.appointmentEndTime}</p>
+                        <p><strong>Service Name:</strong> {appointment.serviceName}</p>
+                        <p><strong>Customer Name:</strong> {appointment.customerName}</p>
+                        <p><strong>Employee Name:</strong> {appointment.employeeName || "Not Assigned"}</p>
+                        <p><strong>Status:</strong> {appointment.status}</p>
 
-                <div className="button-container">
-                  <button
-                    onClick={() =>
-                      handleAssignEmployee(appointment.appointmentId)
-                    }
-                  >
-                    Assign
-                  </button>
-                  <button
-                    onClick={() => handleConfirm(appointment.appointmentId)}
-                    disabled={appointment.status === "CONFIRMED"}
-                  >
-                    {appointment.status === "CONFIRMED"
-                      ? "Confirmed"
-                      : "Confirm"}
-                  </button>
-                  <button
-                    className="delete-button"
-                    onClick={() => handleDelete(appointment.appointmentId)}
-                  >
-                    Delete
-                  </button>
-                  <button onClick={() => handleRescheduleClick(appointment)}>
-                    Reschedule
-                  </button>
-                </div>
+                        <label><strong>Assign Employee:</strong></label>
+                        {loadingEmps ? (
+                            <p>Loading available employees...</p>
+                        ) : (
+                            <select
+                                value={selectedEmployee[appointmentId] || ""}
+                                onChange={(e) => handleEmployeeChange(appointmentId, e.target.value)}
+                            >
+                              <option value="">Select Employee</option>
+                              {possibleEmployees.map((emp) => (
+                                  <option key={emp.employeeId} value={emp.employeeId}>
+                                    {emp.first_name} {emp.last_name}
+                                  </option>
+                              ))}
+                            </select>
+                        )}
+
+                        <div className="button-container">
+                          <button onClick={() => handleAssignEmployee(appointmentId)}>
+                            Assign
+                          </button>
+                          <button
+                              onClick={() => handleConfirm(appointmentId)}
+                              disabled={appointment.status === "CONFIRMED"}
+                          >
+                            {appointment.status === "CONFIRMED" ? "Confirmed" : "Confirm"}
+                          </button>
+                          <button
+                              className="delete-button"
+                              onClick={() => handleDelete(appointmentId)}
+                          >
+                            Delete
+                          </button>
+                          <button onClick={() => handleRescheduleClick(appointment)}>
+                            Reschedule
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                );
+              })}
+            </div>
+        )}
+
+        {showRescheduleModal && (
+            <div className="modal">
+              <h3>Reschedule Appointment</h3>
+              <label>Date:</label>
+              <input type="date" value={newDate} onChange={(e) => setNewDate(e.target.value)} />
+
+              <label>Start Time:</label>
+              <input type="time" value={newStartTime} onChange={(e) => setNewStartTime(e.target.value)} />
+
+              <label>End Time:</label>
+              <input type="time" value={newEndTime} onChange={(e) => setNewEndTime(e.target.value)} />
+
+              <div className="modal-buttons">
+                <button onClick={handleReschedule}>Confirm</button>
+                <button onClick={() => setShowRescheduleModal(false)}>Cancel</button>
               </div>
             </div>
-          ))}
-        </div>
-      )}
-      {showRescheduleModal && (
-        <div className="modal">
-          <h3>Reschedule Appointment</h3>
-          <label>Date:</label>
-          <input
-            type="date"
-            value={newDate}
-            onChange={(e) => setNewDate(e.target.value)}
-          />
-
-          <label>Start Time:</label>
-          <input
-            type="time"
-            value={newStartTime}
-            onChange={(e) => setNewStartTime(e.target.value)}
-          />
-
-          <label>End Time:</label>
-          <input
-            type="time"
-            value={newEndTime}
-            onChange={(e) => setNewEndTime(e.target.value)}
-          />
-
-          <div className="modal-buttons">
-            <button onClick={handleReschedule}>Confirm</button>
-            <button onClick={() => setShowRescheduleModal(false)}>
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
   );
 }


### PR DESCRIPTION
# Employee Availability and Appointment Assignment

## What’s This About?
This PR fixes the issue where admins could assign employees to appointments even if they weren’t available at that time. Now, it only shows employees who are actually free for the appointment.

## What Changed?
### Frontend (React)
- Pulled in appointments and fetched available employees for each one.
- Updated the dashboard to only list employees who can work at that time.

### Backend (Spring Boot)
- Created a new endpoint (`/api/employees/available`) to check which employees are free based on date and time.
- Improved the logic to make sure only available employees show up.
- Tweaked existing employee management stuff to work with the new setup.

## UI Proof
![image](https://github.com/user-attachments/assets/ec565535-ca8b-48b1-81a5-3dcab9f4df70)
