### PR TITLE
(FEAT): Delete Image as Admin

### DIFF
--- a/detailing-be/src/main/java/com/example/highenddetailing/authsubdomain/SecurityConfig.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/authsubdomain/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.highenddetailing.authsubdomain;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -47,6 +48,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/customers/**").permitAll()
                         .requestMatchers("/api/services/**").permitAll()
                         .requestMatchers("/api/employees/**").permitAll()
+
                         .requestMatchers("/api/galleries/**").permitAll()
 
                         //added more here below this comment

--- a/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/businesslayer/GalleryService.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/businesslayer/GalleryService.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface GalleryService {
 
     List<GalleryResponseModel> getAllGalleries();
+    void deleteImage(String galleryId);
 }

--- a/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/businesslayer/GalleryServiceImpl.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/businesslayer/GalleryServiceImpl.java
@@ -26,4 +26,13 @@ public class GalleryServiceImpl implements GalleryService {
     public List<GalleryResponseModel> getAllGalleries() {
         return galleryResponseMapper.entityListToResponseModel(galleryRepository.findAll());
     }
+
+    @Override
+    public void deleteImage(String galleryId) {
+        Gallery gallery = galleryRepository
+                .findByGalleryIdentifier_GalleryId(galleryId)
+                .orElseThrow(() -> new RuntimeException("Gallery not found with id: " + galleryId));
+        galleryRepository.delete(gallery);
+
+    }
 }

--- a/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/datalayer/GalleryRepository.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/datalayer/GalleryRepository.java
@@ -3,6 +3,11 @@ package com.example.highenddetailing.gallerysubdomain.datalayer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface GalleryRepository extends JpaRepository<Gallery, Integer> {
+
+    Optional<Gallery> findByGalleryIdentifier_GalleryId(String galleryId);
+
 }

--- a/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/domainclientlayer/GalleryController.java
+++ b/detailing-be/src/main/java/com/example/highenddetailing/gallerysubdomain/domainclientlayer/GalleryController.java
@@ -2,11 +2,10 @@ package com.example.highenddetailing.gallerysubdomain.domainclientlayer;
 
 import com.example.highenddetailing.gallerysubdomain.businesslayer.GalleryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,5 +22,15 @@ public class GalleryController {
     @GetMapping(produces = "application/json")
     public ResponseEntity<List<GalleryResponseModel>> getAllGalleries() {
         return ResponseEntity.ok().body(galleryService.getAllGalleries());
+    }
+
+    @DeleteMapping("/{galleryId}")
+    public ResponseEntity<Void> deleteGallery(@PathVariable String galleryId) {
+        try {
+            galleryService.deleteImage(galleryId);
+            return  ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
     }
 }

--- a/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/businesslayer/GalleryServiceUnitTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/businesslayer/GalleryServiceUnitTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,5 +66,30 @@ class GalleryServiceUnitTest {
         assertEquals(gallery2.getGalleryIdentifier().getGalleryId(), galleryResponse.get(1).getGalleryId());
         assertEquals("Car Interior 2", galleryResponse.get(1).getDescription());
         assertEquals("gallery2.jpg", galleryResponse.get(1).getImageUrl());
+
+
     }
+
+    @Test
+    void whenDeleteImage_thenGalleryIsDeleted() {
+        // Arrange
+        String galleryId = "gallery1";  // ID of the gallery to delete
+        Gallery gallery = new Gallery();
+        gallery.setId(1);
+        gallery.setGalleryIdentifier(new GalleryIdentifier());
+//        gallery.getGalleryIdentifier().setGalleryId(galleryId);
+        gallery.setDescription("Car Exterior 1");
+        gallery.setImageUrl("gallery1.jpg");
+
+        // Mock behavior
+        when(galleryRepository.findByGalleryIdentifier_GalleryId(galleryId)).thenReturn(java.util.Optional.of(gallery));
+
+        // Act
+        galleryService.deleteImage(galleryId);
+
+        // Assert
+        // Verify that delete was called on the repository
+        verify(galleryRepository).delete(gallery);
+    }
+
 }

--- a/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/datalayer/GalleryRepositoryIntegrationTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/datalayer/GalleryRepositoryIntegrationTest.java
@@ -6,8 +6,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 class GalleryRepositoryIntegrationTest {
@@ -48,4 +47,30 @@ class GalleryRepositoryIntegrationTest {
         assertEquals("Car Interior 2", galleries.get(1).getDescription());
         assertEquals("gallery2.jpg", galleries.get(1).getImageUrl());
     }
+
+
+
+    @Test
+    void whenDeleteImage_thenGalleryIsRemoved() {
+        // Arrange: Create and save a gallery
+        Gallery gallery = new Gallery();
+        GalleryIdentifier identifier = new GalleryIdentifier();
+        gallery.setGalleryIdentifier(identifier);
+        gallery.setDescription("Car Exterior");
+        gallery.setImageUrl("gallery.jpg");
+
+        gallery = galleryRepository.saveAndFlush(gallery);  // Ensure it is saved to the DB
+        String galleryId = gallery.getGalleryIdentifier().getGalleryId();
+
+        assertNotNull(galleryId, "Gallery ID should not be null after saving");
+        assertTrue(galleryRepository.findByGalleryIdentifier_GalleryId(galleryId).isPresent(), "Gallery should exist before deletion");
+
+        // Act: Delete the gallery
+        galleryRepository.delete(gallery);
+        galleryRepository.flush();  // Ensure the deletion is committed
+
+        // Assert: Ensure the gallery no longer exists
+        assertFalse(galleryRepository.findByGalleryIdentifier_GalleryId(galleryId).isPresent(), "Gallery should be removed after deletion");
+    }
+
 }

--- a/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/presentationlayer/GalleriesControllerIntegrationTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/presentationlayer/GalleriesControllerIntegrationTest.java
@@ -3,72 +3,75 @@ package com.example.highenddetailing.gallerysubdomain.presentationlayer;
 import com.example.highenddetailing.gallerysubdomain.datalayer.Gallery;
 import com.example.highenddetailing.gallerysubdomain.datalayer.GalleryIdentifier;
 import com.example.highenddetailing.gallerysubdomain.datalayer.GalleryRepository;
+import com.example.highenddetailing.gallerysubdomain.businesslayer.GalleryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class GalleriesControllerIntegrationTest {
 
     @LocalServerPort
-    private int port;  // This will hold the random port assigned to the embedded server
+    private int port;
 
     @Autowired
-    private GalleryRepository galleryRepository;  // The gallery repository for database interactions
+    private GalleryRepository galleryRepository;
 
-    private RestTemplate restTemplate;  // RestTemplate for making HTTP requests
+    @MockBean
+    private GalleryService galleryService;
+
+    private RestTemplate restTemplate;
+    private String baseUrl;
 
     @BeforeEach
     public void setUp() {
-        restTemplate = new RestTemplate();  // Initialize RestTemplate
+        restTemplate = new RestTemplate();
+        baseUrl = "http://localhost:" + port + "/galleries";
+        galleryRepository.deleteAll();
     }
 
     @BeforeEach
     public void initData() {
-        // Insert mock data into the database (if needed)
         galleryRepository.saveAll(Arrays.asList(
                 new Gallery(new GalleryIdentifier(), "Description of gallery 1", "/images/gallery/gallery1.jpg"),
                 new Gallery(new GalleryIdentifier(), "Description of gallery 2", "/images/gallery/gallery2.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 3", "/images/gallery/gallery3.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 4", "/images/gallery/gallery4.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 5", "/images/gallery/gallery5.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 6", "/images/gallery/gallery6.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 7", "/images/gallery/gallery7.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 8", "/images/gallery/gallery8.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 9", "/images/gallery/gallery9.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 10", "/images/gallery/gallery10.jpg")
+                new Gallery(new GalleryIdentifier(), "Description of gallery 3", "/images/gallery/gallery3.jpg")
         ));
     }
 
 //    @Test
-//    public void whenGetAllGalleries_thenReturnAllGalleries() {
-//        // Construct the URL for the galleries
-//        String url = "http://localhost:" + port + "/api/galleries";  // Use the random port assigned to the app
+//    public void deleteGallery_existingId_shouldReturnNoContent() {
+//        String galleryId = galleryRepository.findAll().get(0).getGalleryIdentifier().getGalleryId();
 //
-//        // Make a GET request to the API
-//        ResponseEntity<List> response = restTemplate.exchange(
-//                url,
-//                org.springframework.http.HttpMethod.GET,
-//                null,
-//                List.class
-//        );
+//        doNothing().when(galleryService).deleteImage(galleryId);
 //
-//        // Assert that the response is OK and contains 10 galleries
-//        assertEquals(HttpStatus.OK, response.getStatusCode());
-//        assertNotNull(response.getBody());
-//        assertEquals(10, response.getBody().size());
+//        ResponseEntity<Void> response = restTemplate.exchange(baseUrl + "/" + galleryId, HttpMethod.DELETE, null, Void.class);
+//
+//        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+//        verify(galleryService, times(1)).deleteImage(galleryId);
 //    }
-
-    // Add more tests for other endpoints or error cases if necessary...
+//
+//    @Test
+//    public void deleteGallery_nonExistingId_shouldReturnNotFound() {
+//        String galleryId = "nonExistingId";
+//
+//        doThrow(new RuntimeException("Gallery not found")).when(galleryService).deleteImage(galleryId);
+//
+//        ResponseEntity<Void> response = restTemplate.exchange(baseUrl + "/" + galleryId, HttpMethod.DELETE, null, Void.class);
+//
+//        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+//        verify(galleryService, times(1)).deleteImage(galleryId);
+//    }
 }

--- a/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/presentationlayer/GalleriesControllerUnitTest.java
+++ b/detailing-be/src/test/java/com/example/highenddetailing/gallerysubdomain/presentationlayer/GalleriesControllerUnitTest.java
@@ -1,8 +1,6 @@
 package com.example.highenddetailing.gallerysubdomain.presentationlayer;
 
 import com.example.highenddetailing.gallerysubdomain.businesslayer.GalleryService;
-import com.example.highenddetailing.gallerysubdomain.datalayer.Gallery;
-import com.example.highenddetailing.gallerysubdomain.datalayer.GalleryIdentifier;
 import com.example.highenddetailing.gallerysubdomain.domainclientlayer.GalleryController;
 import com.example.highenddetailing.gallerysubdomain.domainclientlayer.GalleryResponseModel;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,56 +8,122 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(GalleryController.class)
 public class GalleriesControllerUnitTest {
 
     @Autowired
-    private MockMvc mockMvc; // Inject MockMvc to simulate HTTP requests
+    private MockMvc mockMvc;
 
     @MockBean
-    private GalleryService galleryService; // Mock the GalleryService
+    private GalleryService galleryService;
 
-    private List<Gallery> galleries;
     private List<GalleryResponseModel> galleryResponseModels;
 
     @BeforeEach
     public void setup() {
-        galleries = Arrays.asList(
-                new Gallery(new GalleryIdentifier(), "Description of gallery 1", "/images/gallery/gallery1.jpg"),
-                new Gallery(new GalleryIdentifier(), "Description of gallery 2", "/images/gallery/gallery2.jpg")
-        );
-
         galleryResponseModels = Arrays.asList(
                 GalleryResponseModel.builder()
-                        .galleryId("1")  // Example ID
-                        .description("Description of gallery 1")  // Example Description
-                        .imageUrl("/images/gallery/gallery1.jpg")  // Example Image URL
+                        .galleryId("1")
+                        .description("Description of gallery 1")
+                        .imageUrl("/images/gallery/gallery1.jpg")
                         .build(),
                 GalleryResponseModel.builder()
                         .galleryId("2")
                         .description("Description of gallery 2")
                         .imageUrl("/images/gallery/gallery2.jpg")
-                        .build());
+                        .build()
+        );
     }
 
-//    @Test
-//    public void whenGetAllGalleries_thenReturnAllGalleries() throws Exception {
-//        // Mock the service to return predefined data
-//        when(galleryService.getAllGalleries()).thenReturn(galleryResponseModels);
+    @Test
+    @WithMockUser(username = "testuser", roles = "ADMIN")
+    public void whenGetAllGalleries_thenReturnAllGalleries() throws Exception {
+        when(galleryService.getAllGalleries()).thenReturn(galleryResponseModels);
+
+        mockMvc.perform(get("/api/galleries"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2))
+                .andExpect(jsonPath("$[0].description").value("Description of gallery 1"))
+                .andExpect(jsonPath("$[1].description").value("Description of gallery 2"));
+    }
 //
-//        // Perform the GET request and verify the response
-//        mockMvc.perform(get("/api/galleries"))
-//                .andExpect(status().isOk())  // Assert the status is 200 OK
-//                .andExpect(jsonPath("$.size()").value(2));  // Assert there are 2 galleries in the response
+//    @Test
+//    public void whenDeleteGallery_thenNoContent() throws Exception {
+//        String galleryId = "1";
+//        doNothing().when(galleryService).deleteImage(galleryId);
+//
+//        // Mock JWT
+//        Jwt jwt = Jwt.withTokenValue("token")
+//                .header("alg", "none")
+//                .claim("roles", Collections.singletonList("ADMIN"))
+//                .issuer("https://dev-vmtwqb6p6lr3if0d.us.auth0.com/")
+//                .issuedAt(Instant.now())
+//                .expiresAt(Instant.now().plusSeconds(3600))
+//                .build();
+//
+//        // JwtAuthenticationToken
+//        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(jwt, Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN")));
+//
+//        // Mock HttpServletRequest
+//        MockHttpServletRequest request = new MockHttpServletRequest();
+//        request.setScheme("http");
+//        request.setServerName("localhost"); //use your backend url here.
+//        request.setServerPort(8081); // Standard HTTPS port
+//        request.setRequestURI("/api/galleries/" + galleryId);
+//        request.setMethod("DELETE");
+//
+//        mockMvc.perform(delete("/api/galleries/" + galleryId)
+//                        .with(req -> {
+//                            req.setUserPrincipal(authenticationToken);
+//                            return req;
+//                        })
+//                        .requestAttr(MockHttpServletRequest.class.getName(), request)) // Add the request attributes.
+//                .andExpect(status().isNoContent());
+//
+//        verify(galleryService, times(1)).deleteImage(galleryId);
+//    }
+//    @Test
+//    public void whenDeleteGallery_galleryNotFound_thenNotFound() throws Exception {
+//        String galleryId = "nonexistent";
+//        doThrow(new RuntimeException("Gallery not found")).when(galleryService).deleteImage(galleryId);
+//
+//        // Mock JWT
+//        Jwt jwt = Jwt.withTokenValue("token")
+//                .header("alg", "none")
+//                .claim("sub", "testuser") // Add the 'sub' claim
+//                .claim("roles", Collections.singletonList("ROLE_ADMIN"))
+//                .issuer("https://dev-vmtwqb6p6lr3if0d.us.auth0.com/")
+//                .issuedAt(Instant.now())
+//                .expiresAt(Instant.now().plusSeconds(3600))
+//                .build();
+//
+//        // JwtAuthenticationToken
+//        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(jwt, Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN")));
+//
+//        mockMvc.perform(delete("/api/galleries/" + galleryId)
+//                        .with(request -> {
+//                            request.setUserPrincipal(authenticationToken);
+//                            return request;
+//                        }))
+//                .andExpect(status().isNotFound());
+//
+//        verify(galleryService, times(1)).deleteImage(galleryId);
 //    }
 }

--- a/detailing-fe/src/models/AllGalleries.css
+++ b/detailing-fe/src/models/AllGalleries.css
@@ -189,3 +189,35 @@
 body {
   background-color: black;
 }
+
+/* Delete Button */
+.delete-button {
+  background-color: red;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 5px;
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  width: auto;
+  min-width: 50px;
+  text-align: center;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.delete-button:hover {
+  background-color: darkred;
+  transform: scale(1.05);
+}
+
+/* Ensure gallery-item has relative positioning */
+.gallery-item {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}

--- a/detailing-fe/src/models/AllGalleries.css
+++ b/detailing-fe/src/models/AllGalleries.css
@@ -205,7 +205,9 @@ body {
   width: auto;
   min-width: 50px;
   text-align: center;
-  transition: background-color 0.3s ease, transform 0.2s ease;
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
 }
 
 .delete-button:hover {

--- a/detailing-fe/src/models/AllGalleries.tsx
+++ b/detailing-fe/src/models/AllGalleries.tsx
@@ -7,7 +7,7 @@ import axios from "axios";
 import React, { useEffect, useState } from "react";
 import { GalleryModel } from "./dtos/GalleryModel";
 import "./AllGalleries.css";
-import { toast, ToastContainer } from "react-toastify";  // Added ToastContainer import
+import { toast, ToastContainer } from "react-toastify"; // Added ToastContainer import
 import "react-toastify/dist/ReactToastify.css";
 import { useAuth0 } from "@auth0/auth0-react"; // Import useAuth0
 
@@ -39,7 +39,8 @@ export default function AllGalleries(): JSX.Element {
         const base64Url = accessToken.split(".")[1];
         const decodedPayload = atob(base64Url);
         const tokenData = JSON.parse(decodedPayload);
-        const roles = tokenData["https://highenddetailing/roles"] || tokenData.roles || [];
+        const roles =
+          tokenData["https://highenddetailing/roles"] || tokenData.roles || [];
         setIsAdmin(roles.includes("ADMIN"));
       } catch (error) {
         console.error("Error fetching access token or roles:", error);
@@ -52,7 +53,9 @@ export default function AllGalleries(): JSX.Element {
   const deleteGallery = async (galleryId: string) => {
     try {
       await axios.delete(`http://localhost:8081/api/galleries/${galleryId}`);
-      setGalleries(galleries.filter(gallery => gallery.galleryId !== galleryId));
+      setGalleries(
+        galleries.filter((gallery) => gallery.galleryId !== galleryId),
+      );
       toast.success("Image deleted successfully");
     } catch (error) {
       console.error("Error deleting image", error);
@@ -61,8 +64,11 @@ export default function AllGalleries(): JSX.Element {
   };
 
   return (
-    <div className="gallery-container" >
-      <h2 className="gallery-title" style={{ textAlign: "center", color: "white" }}>
+    <div className="gallery-container">
+      <h2
+        className="gallery-title"
+        style={{ textAlign: "center", color: "white" }}
+      >
         Gallery
       </h2>
       <Swiper
@@ -89,7 +95,10 @@ export default function AllGalleries(): JSX.Element {
                 onClick={() => setSelectedImage(gallery.imageUrl)}
               />
               {isAdmin && (
-                <button className="delete-button" onClick={() => deleteGallery(gallery.galleryId)}>
+                <button
+                  className="delete-button"
+                  onClick={() => deleteGallery(gallery.galleryId)}
+                >
                   Delete
                 </button>
               )}
@@ -97,19 +106,24 @@ export default function AllGalleries(): JSX.Element {
           </SwiperSlide>
         ))}
       </Swiper>
-
       {/* Lightbox (Full-Screen Preview) */}
       {selectedImage && (
         <div className="lightbox" onClick={() => setSelectedImage(null)}>
           <div className="lightbox-content">
-            <button className="close-button" onClick={() => setSelectedImage(null)}>
+            <button
+              className="close-button"
+              onClick={() => setSelectedImage(null)}
+            >
               ✖
             </button>
-            <img className="lightbox-image" src={selectedImage} alt="Full Preview" />
+            <img
+              className="lightbox-image"
+              src={selectedImage}
+              alt="Full Preview"
+            />
           </div>
         </div>
       )}
-
       <ToastContainer /> {/* Add this ToastContainer to display the toasts */}
     </div>
   );

--- a/detailing-fe/src/models/AllGalleries.tsx
+++ b/detailing-fe/src/models/AllGalleries.tsx
@@ -61,7 +61,7 @@ export default function AllGalleries(): JSX.Element {
   };
 
   return (
-    <div className="gallery-container" style={{ backgroundColor: "black" }}>
+    <div className="gallery-container" >
       <h2 className="gallery-title" style={{ textAlign: "center", color: "white" }}>
         Gallery
       </h2>

--- a/detailing-fe/src/models/AllGalleries.tsx
+++ b/detailing-fe/src/models/AllGalleries.tsx
@@ -7,12 +7,17 @@ import axios from "axios";
 import React, { useEffect, useState } from "react";
 import { GalleryModel } from "./dtos/GalleryModel";
 import "./AllGalleries.css";
+import { toast, ToastContainer } from "react-toastify";  // Added ToastContainer import
+import "react-toastify/dist/ReactToastify.css";
+import { useAuth0 } from "@auth0/auth0-react"; // Import useAuth0
 
 export default function AllGalleries(): JSX.Element {
   const apiBaseUrl = process.env.REACT_APP_API_BASE_URL;
+  const { getAccessTokenSilently } = useAuth0(); // Get access token to check user roles
 
   const [galleries, setGalleries] = useState<GalleryModel[]>([]);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchGalleries = async (): Promise<void> => {
@@ -27,12 +32,37 @@ export default function AllGalleries(): JSX.Element {
     fetchGalleries();
   }, []);
 
+  useEffect(() => {
+    const checkIfUserIsAdmin = async () => {
+      try {
+        const accessToken = await getAccessTokenSilently();
+        const base64Url = accessToken.split(".")[1];
+        const decodedPayload = atob(base64Url);
+        const tokenData = JSON.parse(decodedPayload);
+        const roles = tokenData["https://highenddetailing/roles"] || tokenData.roles || [];
+        setIsAdmin(roles.includes("ADMIN"));
+      } catch (error) {
+        console.error("Error fetching access token or roles:", error);
+      }
+    };
+
+    checkIfUserIsAdmin();
+  }, [getAccessTokenSilently]);
+
+  const deleteGallery = async (galleryId: string) => {
+    try {
+      await axios.delete(`http://localhost:8081/api/galleries/${galleryId}`);
+      setGalleries(galleries.filter(gallery => gallery.galleryId !== galleryId));
+      toast.success("Image deleted successfully");
+    } catch (error) {
+      console.error("Error deleting image", error);
+      toast.error("Failed to delete image");
+    }
+  };
+
   return (
     <div className="gallery-container" style={{ backgroundColor: "black" }}>
-      <h2
-        className="gallery-title"
-        style={{ textAlign: "center", color: "white" }}
-      >
+      <h2 className="gallery-title" style={{ textAlign: "center", color: "white" }}>
         Gallery
       </h2>
       <Swiper
@@ -51,12 +81,19 @@ export default function AllGalleries(): JSX.Element {
       >
         {galleries.map((gallery) => (
           <SwiperSlide key={gallery.galleryId} className="swiper-slide">
-            <img
-              className="gallery-image"
-              src={gallery.imageUrl}
-              alt={gallery.description}
-              onClick={() => setSelectedImage(gallery.imageUrl)}
-            />
+            <div className="gallery-item">
+              <img
+                className="gallery-image"
+                src={gallery.imageUrl}
+                alt={gallery.description}
+                onClick={() => setSelectedImage(gallery.imageUrl)}
+              />
+              {isAdmin && (
+                <button className="delete-button" onClick={() => deleteGallery(gallery.galleryId)}>
+                  Delete
+                </button>
+              )}
+            </div>
           </SwiperSlide>
         ))}
       </Swiper>
@@ -65,20 +102,15 @@ export default function AllGalleries(): JSX.Element {
       {selectedImage && (
         <div className="lightbox" onClick={() => setSelectedImage(null)}>
           <div className="lightbox-content">
-            <button
-              className="close-button"
-              onClick={() => setSelectedImage(null)}
-            >
+            <button className="close-button" onClick={() => setSelectedImage(null)}>
               ✖
             </button>
-            <img
-              className="lightbox-image"
-              src={selectedImage}
-              alt="Full Preview"
-            />
+            <img className="lightbox-image" src={selectedImage} alt="Full Preview" />
           </div>
         </div>
       )}
+
+      <ToastContainer /> {/* Add this ToastContainer to display the toasts */}
     </div>
   );
 }

--- a/detailing-fe/src/pages/DashhoardPage.tsx
+++ b/detailing-fe/src/pages/DashhoardPage.tsx
@@ -7,6 +7,7 @@ import AllEmployees from "../models/allEmployees";
 import "./DashboardPage.css";
 import ReportsTable from "../models/ReportsTable";
 import AppointmentsTable from "../models/AppointmentsTable";
+import AllGalleries from "../models/AllGalleries";
 
 export default function DashboardPage(): JSX.Element {
   const apiBaseUrl = process.env.REACT_APP_API_BASE_URL;
@@ -73,6 +74,10 @@ export default function DashboardPage(): JSX.Element {
         <div className="section-container">
           <h2 className="section-title">Employees</h2>
           <AllEmployees />
+        </div>
+        <div className="section-container">
+          <h2 className="section-title">Galleryy</h2>
+          <AllGalleries />
         </div>
       </div>
     </div>

--- a/detailing-fe/src/pages/DashhoardPage.tsx
+++ b/detailing-fe/src/pages/DashhoardPage.tsx
@@ -75,8 +75,15 @@ export default function DashboardPage(): JSX.Element {
           <h2 className="section-title">Employees</h2>
           <AllEmployees />
         </div>
-        <div className="section-container">
-          <h2 className="section-title">Galleryy</h2>
+        <div
+          className="section-container"
+          style={{
+            backgroundColor: "white",
+            padding: "20px",
+            borderRadius: "10px",
+          }}
+        >
+          <h2 className="section-title">Gallery</h2>
           <AllGalleries />
         </div>
       </div>

--- a/detailing-fe/src/pages/OnboardingForm.tsx
+++ b/detailing-fe/src/pages/OnboardingForm.tsx
@@ -3,100 +3,100 @@ import { useAuth0 } from "@auth0/auth0-react";
 import "./OnboardingForm.css";
 
 export function OnboardingForm() {
-    const [formData, setFormData] = useState({
-        customerFirstName: "",
-        customerLastName: "",
-        customerEmailAddress: "",
-        streetAddress: "",
-        city: "",
-        postalCode: "",
-        province: "",
-        country: "",
+  const [formData, setFormData] = useState({
+    customerFirstName: "",
+    customerLastName: "",
+    customerEmailAddress: "",
+    streetAddress: "",
+    city: "",
+    postalCode: "",
+    province: "",
+    country: "",
+  });
+
+  const { loginWithRedirect } = useAuth0();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    // Save form to localStorage
+    console.log("Form Data to be saved:", formData);
+    localStorage.setItem("customFormData", JSON.stringify(formData));
+
+    // Redirect to Auth0 signup page
+    await loginWithRedirect({
+      authorizationParams: {
+        prompt: "login",
+        screen_hint: "signup",
+      },
     });
+  };
 
-    const { loginWithRedirect } = useAuth0();
-
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        setFormData({ ...formData, [name]: value });
-    };
-
-    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-
-        // Save form to localStorage
-        console.log("Form Data to be saved:", formData);
-        localStorage.setItem("customFormData", JSON.stringify(formData));
-
-        // Redirect to Auth0 signup page
-        await loginWithRedirect({
-            authorizationParams: {
-                prompt: "login",
-                screen_hint: "signup",
-            },
-        });
-    };
-
-    return (
-        <form onSubmit={handleSubmit}>
-            <h2>Onboarding Form</h2>
-            <input
-                type="text"
-                name="customerFirstName"
-                placeholder="First Name"
-                onChange={handleChange}
-                required
-            />
-            <input
-                type="text"
-                name="customerLastName"
-                placeholder="Last Name"
-                onChange={handleChange}
-                required
-            />
-            <input
-                type="email"
-                name="customerEmailAddress"
-                placeholder="Email"
-                onChange={handleChange}
-                required
-            />
-            <input
-                type="text"
-                name="streetAddress"
-                placeholder="Street Address"
-                onChange={handleChange}
-                required
-            />
-            <input
-                type="text"
-                name="city"
-                placeholder="City"
-                onChange={handleChange}
-                required
-            />
-            <input
-                type="text"
-                name="postalCode"
-                placeholder="Postal Code"
-                onChange={handleChange}
-                required
-            />
-            <input
-                type="text"
-                name="province"
-                placeholder="Province"
-                onChange={handleChange}
-                required
-            />
-            <input
-                type="text"
-                name="country"
-                placeholder="Country"
-                onChange={handleChange}
-                required
-            />
-            <button type="submit">Submit</button>
-        </form>
-    );
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Onboarding Form</h2>
+      <input
+        type="text"
+        name="customerFirstName"
+        placeholder="First Name"
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="text"
+        name="customerLastName"
+        placeholder="Last Name"
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="email"
+        name="customerEmailAddress"
+        placeholder="Email"
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="text"
+        name="streetAddress"
+        placeholder="Street Address"
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="text"
+        name="city"
+        placeholder="City"
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="text"
+        name="postalCode"
+        placeholder="Postal Code"
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="text"
+        name="province"
+        placeholder="Province"
+        onChange={handleChange}
+        required
+      />
+      <input
+        type="text"
+        name="country"
+        placeholder="Country"
+        onChange={handleChange}
+        required
+      />
+      <button type="submit">Submit</button>
+    </form>
+  );
 }

--- a/detailing-fe/tests/deleteImageAdmin.spec.ts
+++ b/detailing-fe/tests/deleteImageAdmin.spec.ts
@@ -1,16 +1,18 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('Delete Image as Admin', async ({ page }) => {
-  await page.goto('http://localhost:3000/home');
-  await page.getByRole('button', { name: 'Login' }).click();
-  await page.getByLabel('Email address').click();
-  await page.getByLabel('Email address').fill('admin@admin.com');
-  await page.getByLabel('Password').click();
-  await page.getByLabel('Password').fill('Admin33##');
-  await page.getByRole('button', { name: 'Continue', exact: true }).click();
-  await page.getByRole('link', { name: 'Dashboard' }).first().click();
-  await page.locator('div:nth-child(4) > .gallery-item > .delete-button').click();
-  
+test("Delete Image as Admin", async ({ page }) => {
+  await page.goto("http://localhost:3000/home");
+  await page.getByRole("button", { name: "Login" }).click();
+  await page.getByLabel("Email address").click();
+  await page.getByLabel("Email address").fill("admin@admin.com");
+  await page.getByLabel("Password").click();
+  await page.getByLabel("Password").fill("Admin33##");
+  await page.getByRole("button", { name: "Continue", exact: true }).click();
+  await page.getByRole("link", { name: "Dashboard" }).first().click();
+  await page
+    .locator("div:nth-child(4) > .gallery-item > .delete-button")
+    .click();
+
   // Assertion to check if the success message is visible
-  await expect(page.getByText('Image deleted successfully')).toBeVisible();
+  await expect(page.getByText("Image deleted successfully")).toBeVisible();
 });

--- a/detailing-fe/tests/deleteImageAdmin.spec.ts
+++ b/detailing-fe/tests/deleteImageAdmin.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Delete Image as Admin', async ({ page }) => {
+  await page.goto('http://localhost:3000/home');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await page.getByLabel('Email address').click();
+  await page.getByLabel('Email address').fill('admin@admin.com');
+  await page.getByLabel('Password').click();
+  await page.getByLabel('Password').fill('Admin33##');
+  await page.getByRole('button', { name: 'Continue', exact: true }).click();
+  await page.getByRole('link', { name: 'Dashboard' }).first().click();
+  await page.locator('div:nth-child(4) > .gallery-item > .delete-button').click();
+  
+  // Assertion to check if the success message is visible
+  await expect(page.getByText('Image deleted successfully')).toBeVisible();
+});

--- a/detailing-fe/tests/test-1.spec.ts
+++ b/detailing-fe/tests/test-1.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+  // Recording...
+});

--- a/detailing-fe/tests/test-1.spec.ts
+++ b/detailing-fe/tests/test-1.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('test', async ({ page }) => {
+test("test", async ({ page }) => {
   // Recording...
 });


### PR DESCRIPTION
# 🔥 Delete Image as Admin  

## Description  
This PR implements the ability for an **admin user** to delete images from the gallery.  
- Added a **delete button** for admins in the `AllGalleries` component.  
- Integrated **toast notifications** to confirm image deletion (`"Image deleted successfully"`).  
- Ensured API call to `/api/galleries/:galleryId` deletes the selected image.  

## Changes Made  
- **Updated:** `AllGalleries.tsx`  
  - Checks for admin role before showing the delete button.  
  - Uses `axios.delete` to remove the image.  
  - Displays a toast notification when an image is deleted.  
- **Updated:** `DashboardPage.tsx`  
  - Wrapped `AllGalleries` inside a white background container for better UI.  
- **Updated:** `AllGalleries.css`  
  - Styled delete button and gallery container.  
  - Testing

## Screenshots (if applicable)  
![image](https://github.com/user-attachments/assets/b283cbf3-47d3-4706-b83f-909d662113e3)
![image](https://github.com/user-attachments/assets/64afeed0-b0c3-40f2-b0c1-7f405c8213ce)


## How to Test  
1. Log in as an **admin** user.  
2. Navigate to the **Gallery** or **Dashboard** section.  
3. Click the **"Delete"** button on any image.  
4. Ensure the image disappears and **"Image deleted successfully"** appears as a toast notification.  
5. Refresh the page to confirm the deletion persists.  

## Checklist  
- [x] Code follows project conventions.  
- [x] PR description is clear and detailed.  
- [x] Functionality is tested and works as expected.  
- [x] No console errors or warnings.  

